### PR TITLE
Upgrade to petgraph 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ repository = "https://github.com/mitchmindtree/daggy.git"
 homepage = "https://github.com/mitchmindtree/daggy"
 
 [dependencies]
-petgraph = "0.2.2"
+petgraph = { version = "0.3.0", default-features = false }

--- a/benches/add_edges.rs
+++ b/benches/add_edges.rs
@@ -1,0 +1,49 @@
+
+#![feature(test)]
+
+extern crate test;
+extern crate daggy;
+
+use test::Bencher;
+
+use daggy::Dag;
+use daggy::NodeIndex;
+struct Weight;
+
+
+#[bench]
+fn add_edge(bench: &mut Bencher) {
+    let max_node = 10;
+    let edges = &[(1, 4), (3, 4), (2, 5), (3, 5), (2, 8), (1, 9), (1, 8),
+                  (1, 3), (2, 7), (1, 7), (0, 6), (1, 2), (0, 7), (1, 6),
+                  (2, 4), (0, 1), (0, 9), (2, 9), (2, 6), (0, 4), (2, 3),
+                  (0, 2), (0, 3), (0, 5), (0, 8), (1, 5)];
+    let mut dag = Dag::<Weight, u32, u32>::with_capacity(max_node, edges.len());
+    for _ in 0..max_node {
+        dag.add_node(Weight);
+    }
+
+    bench.iter(|| {
+        dag.clear_edges();
+        edges.iter().all(|&(a, b)|
+            dag.add_edge(NodeIndex::new(a), NodeIndex::new(b), 0).is_ok())
+    });
+}
+
+#[bench]
+fn add_edges(bench: &mut Bencher) {
+    let max_node = 10;
+    let edges = &[(1, 4), (3, 4), (2, 5), (3, 5), (2, 8), (1, 9), (1, 8),
+                  (1, 3), (2, 7), (1, 7), (0, 6), (1, 2), (0, 7), (1, 6),
+                  (2, 4), (0, 1), (0, 9), (2, 9), (2, 6), (0, 4), (2, 3),
+                  (0, 2), (0, 3), (0, 5), (0, 8), (1, 5)];
+    let mut dag = Dag::<Weight, u32, u32>::with_capacity(max_node, edges.len());
+    for _ in 0..max_node {
+        dag.add_node(Weight);
+    }
+
+    bench.iter(|| {
+        dag.clear_edges();
+        dag.add_edges(edges.iter().map(|&(a, b)| (NodeIndex::new(a), NodeIndex::new(b), 0)))
+    });
+}

--- a/tests/add_edges.rs
+++ b/tests/add_edges.rs
@@ -2,6 +2,7 @@
 extern crate daggy;
 
 use daggy::{Dag, WouldCycle};
+use daggy::NodeIndex;
 use std::iter::once;
 
 struct Weight;
@@ -44,5 +45,35 @@ fn add_edges_err() {
     match add_edges_result {
         Err(WouldCycle(returned_weights)) => assert_eq!(returned_weights, vec![3, 2, 1, 0]),
         Ok(_) => panic!("Should have been an error"),
+    }
+}
+
+#[test]
+fn add_edges_more() {
+    let mut dag = Dag::<Weight, u32, u32>::new();
+    let root = dag.add_node(Weight);
+    let a = dag.add_node(Weight);
+    let b = dag.add_node(Weight);
+    let c = dag.add_node(Weight);
+
+    assert!(dag.add_edge(root, a, 0).is_ok());
+    assert!(dag.add_edge(root, b, 0).is_ok());
+    assert!(dag.add_edge(root, c, 0).is_ok());
+    assert!(dag.add_edge(c, root, 0).is_err());
+}
+
+#[test]
+fn add_edges_more2() {
+    let max_node = 10;
+    let edges = &[(1, 4), (3, 4), (2, 5), (3, 5), (2, 8), (1, 9), (1, 8),
+                  (1, 3), (2, 7), (1, 7), (0, 6), (1, 2), (0, 7), (1, 6),
+                  (2, 4), (0, 1), (0, 9), (2, 9), (2, 6), (0, 4), (2, 3),
+                  (0, 2), (0, 3), (0, 5), (0, 8), (1, 5)];
+    let mut dag = Dag::<Weight, u32, u32>::with_capacity(max_node, edges.len());
+    for _ in 0..max_node {
+        dag.add_node(Weight);
+    }
+    for &(a, b) in edges {
+        assert!(dag.add_edge(NodeIndex::new(a), NodeIndex::new(b), 0).is_ok());
     }
 }


### PR DESCRIPTION
Use newest petgraph.

Use their workspace reuse for cycle detection. Also uses a simpler (local) has_path_connecting function for adding a single edge.

It's a good improvement (with keeping the DfsSpace around or not) for add_edge, and a smaller change to add_edges.

Note: Requires Rust 1.12.

Edited: Some background information of the problem at hand in general http://stackoverflow.com/a/20298238/
