### PR TITLE
Conform to latest petgraph. Remove `Walker` in favour of petgraph trait.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rust:
 script:
 - cargo build --verbose
 - cargo test --verbose
+- cargo test --all-features --verbose
 - cargo doc --verbose
 after_success: |
   [ $TRAVIS_BRANCH = master ] &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "daggy"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A directed acyclic graph data structure library. It is Implemented on top of petgraph's Graph data structure and attempts to follow similar conventions where suitable."
 readme = "README.md"
@@ -10,4 +10,11 @@ repository = "https://github.com/mitchmindtree/daggy.git"
 homepage = "https://github.com/mitchmindtree/daggy"
 
 [dependencies]
-petgraph = { version = "0.4.5", default-features = false }
+petgraph = { version = "0.4", default-features = false }
+serde = { version = "1.0", optional = true }
+
+[features]
+serde-1 = ["petgraph/serde-1", "serde"]
+
+[package.metadata.docs.rs]
+features = ["serde-1"]

--- a/README.md
+++ b/README.md
@@ -1,16 +1,9 @@
-# daggy [![Build Status](https://travis-ci.org/mitchmindtree/daggy.svg?branch=master)](https://travis-ci.org/mitchmindtree/daggy) [![Crates.io](https://img.shields.io/crates/v/daggy.svg)](https://crates.io/crates/daggy) [![Crates.io](https://img.shields.io/crates/l/daggy.svg)](https://github.com/mitchmindtree/daggy/blob/master/LICENSE-MIT)
-
+# daggy [![Build Status](https://travis-ci.org/mitchmindtree/daggy.svg?branch=master)](https://travis-ci.org/mitchmindtree/daggy) [![Crates.io](https://img.shields.io/crates/v/daggy.svg)](https://crates.io/crates/daggy) [![Crates.io](https://img.shields.io/crates/l/daggy.svg)](https://github.com/mitchmindtree/daggy/blob/master/LICENSE-MIT) [![docs.rs](https://docs.rs/daggy/badge.svg)](https://docs.rs/daggy/)
 
 
 A [directed acyclic graph](https://en.wikipedia.org/wiki/Directed_acyclic_graph) data structure for Rust.
 
-It is Implemented on top of [petgraph](https://github.com/bluss/petulant-avenger-graphlibrary)'s [Graph](http://bluss.github.io/petulant-avenger-graphlibrary/doc/petgraph/graph/struct.Graph.html) data structure and attempts to follow similar conventions where suitable.
-
-
-Documentation
--------------
-
-[API documentation here!](http://mitchmindtree.github.io/daggy/daggy)
+It is Implemented on top of [petgraph](https://github.com/bluss/petulant-avenger-graphlibrary)'s [Graph](https://docs.rs/petgraph/0.4.11/petgraph/graph/struct.Graph.html) data structure and attempts to follow similar conventions where suitable.
 
 
 Usage

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,29 +15,34 @@
 #![warn(missing_docs)]
 
 pub extern crate petgraph;
-use petgraph as pg;
+#[cfg(feature = "serde-1")]
+extern crate serde;
 
-use petgraph::graph::{DefaultIx, GraphIndex, IndexType};
+use petgraph as pg;
+use petgraph::algo::{has_path_connecting, DfsSpace};
+use petgraph::graph::{DefaultIx, DiGraph, GraphIndex, IndexType};
+use petgraph::visit::{GetAdjacencyMatrix, GraphBase, GraphProp, IntoEdgeReferences, IntoEdges,
+                      IntoEdgesDirected, IntoNeighbors, IntoNeighborsDirected,
+                      IntoNodeIdentifiers, IntoNodeReferences, NodeCompactIndexable, NodeCount,
+                      NodeIndexable, Visitable};
+use petgraph::IntoWeightedEdge;
+#[cfg(feature = "serde-1")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::marker::PhantomData;
 use std::ops::{Index, IndexMut};
 
-pub use petgraph::graph::{EdgeIndex, NodeIndex, EdgeWeightsMut, NodeWeightsMut};
-pub use walker::Walker;
-
-use petgraph::algo::{DfsSpace, has_path_connecting};
-use petgraph::visit::Visitable;
+// Petgraph re-exports.
+pub use petgraph::graph::{EdgeIndex, EdgeWeightsMut, NodeIndex, NodeWeightsMut};
+pub use petgraph::visit::Walker;
 
 pub mod walker;
-
-
-/// The Petgraph to be used internally within the Dag for storing/managing nodes and edges.
-pub type PetGraph<N, E, Ix> = pg::Graph<N, E, pg::Directed, Ix>;
 
 /// Read only access into a **Dag**'s internal node array.
 pub type RawNodes<'a, N, Ix> = &'a [pg::graph::Node<N, Ix>];
 /// Read only access into a **Dag**'s internal edge array.
 pub type RawEdges<'a, E, Ix> = &'a [pg::graph::Edge<E, Ix>];
-
+/// An iterator yielding all edges to/from some node.
+pub type Edges<'a, E, Ix> = pg::graph::Edges<'a, E, pg::Directed, Ix>;
 
 /// A Directed acyclic graph (DAG) data structure.
 ///
@@ -64,10 +69,9 @@ pub type RawEdges<'a, E, Ix> = &'a [pg::graph::Edge<E, Ix>];
 /// for taking advantage of petgraph's various graph-related algorithms.
 #[derive(Clone, Debug)]
 pub struct Dag<N, E, Ix: IndexType = DefaultIx> {
-    graph: PetGraph<N, E, Ix>,
-    cycle_state: DfsSpace<NodeIndex<Ix>, <PetGraph<N, E, Ix> as Visitable>::Map>,
+    graph: DiGraph<N, E, Ix>,
+    cycle_state: DfsSpace<NodeIndex<Ix>, <DiGraph<N, E, Ix> as Visitable>::Map>,
 }
-
 
 /// A **Walker** type that can be used to step through the children of some parent node.
 pub struct Children<N, E, Ix: IndexType> {
@@ -75,7 +79,6 @@ pub struct Children<N, E, Ix: IndexType> {
     _node: PhantomData<N>,
     _edge: PhantomData<E>,
 }
-
 
 /// A **Walker** type that can be used to step through the parents of some child node.
 pub struct Parents<N, E, Ix: IndexType> {
@@ -86,22 +89,22 @@ pub struct Parents<N, E, Ix: IndexType> {
 
 /// An iterator yielding multiple `EdgeIndex`s, returned by the `Graph::add_edges` method.
 pub struct EdgeIndices<Ix: IndexType> {
-    indices: ::std::ops::Range<usize>,
+    indices: std::ops::Range<usize>,
     _phantom: PhantomData<Ix>,
 }
 
 /// An alias to simplify the **Recursive** **Walker** type returned by **Dag**.
-pub type RecursiveWalk<N, E, Ix, F> = walker::Recursive<Dag<N, E, Ix>, Ix, F>;
-
+pub type RecursiveWalk<N, E, Ix, F> = walker::Recursive<Dag<N, E, Ix>, F>;
 
 /// An error returned by the `Dag::add_edge` method in the case that adding an edge would have
 /// caused the graph to cycle.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone)]
 pub struct WouldCycle<E>(pub E);
 
-
-impl<N, E, Ix> Dag<N, E, Ix> where Ix: IndexType {
-
+impl<N, E, Ix> Dag<N, E, Ix>
+where
+    Ix: IndexType,
+{
     /// Create a new, empty `Dag`.
     pub fn new() -> Self {
         Self::with_capacity(1, 1)
@@ -110,8 +113,129 @@ impl<N, E, Ix> Dag<N, E, Ix> where Ix: IndexType {
     /// Create a new `Dag` with estimated capacity for its node and edge Vecs.
     pub fn with_capacity(nodes: usize, edges: usize) -> Self {
         Dag {
-            graph: PetGraph::with_capacity(nodes, edges),
+            graph: DiGraph::with_capacity(nodes, edges),
             cycle_state: DfsSpace::default(),
+        }
+    }
+
+    /// Create a `Dag` from an iterator yielding edges.
+    ///
+    /// Node weights `N` are set to default values.
+    ///
+    /// `Edge` weights `E` may either be specified in the list, or they are filled with default
+    /// values.
+    ///
+    /// Nodes are inserted automatically to match the edges.
+    ///
+    /// Returns an `Err` if adding any of the edges would cause a cycle.
+    pub fn from_edges<I>(edges: I) -> Result<Self, WouldCycle<E>>
+    where
+        I: IntoIterator,
+        I::Item: IntoWeightedEdge<E>,
+        <I::Item as IntoWeightedEdge<E>>::NodeId: Into<NodeIndex<Ix>>,
+        N: Default,
+    {
+        let mut dag = Self::default();
+        dag.extend_with_edges(edges)?;
+        Ok(dag)
+    }
+
+    /// Extend the `Dag` with the given edges.
+    ///
+    /// Node weights `N` are set to default values.
+    ///
+    /// Edge weights `E` may either be specified in the list, or they are filled with default
+    /// values.
+    ///
+    /// Nodes are inserted automatically to match the edges.
+    ///
+    /// Returns an `Err` if adding an edge would cause a cycle.
+    pub fn extend_with_edges<I>(&mut self, edges: I) -> Result<(), WouldCycle<E>>
+    where
+        I: IntoIterator,
+        I::Item: IntoWeightedEdge<E>,
+        <I::Item as IntoWeightedEdge<E>>::NodeId: Into<NodeIndex<Ix>>,
+        N: Default,
+    {
+        for edge in edges {
+            let (source, target, weight) = edge.into_weighted_edge();
+            let (source, target) = (source.into(), target.into());
+            let nx = std::cmp::max(source, target);
+            while nx.index() >= self.node_count() {
+                self.add_node(N::default());
+            }
+            self.add_edge(source, target, weight)?;
+        }
+        Ok(())
+    }
+
+    /// Create a `Dag` from an iterator yielding elements.
+    ///
+    /// Returns an `Err` if an edge would cause a cycle within the graph.
+    pub fn from_elements<I>(elements: I) -> Result<Self, WouldCycle<E>>
+    where
+        Self: Sized,
+        I: IntoIterator<Item = pg::data::Element<N, E>>,
+    {
+        let mut dag = Self::default();
+        for elem in elements {
+            match elem {
+                pg::data::Element::Node { weight } => {
+                    dag.add_node(weight);
+                }
+                pg::data::Element::Edge {
+                    source,
+                    target,
+                    weight,
+                } => {
+                    let n = NodeIndex::new(source);
+                    let e = NodeIndex::new(target);
+                    dag.update_edge(n, e, weight)?;
+                }
+            }
+        }
+        Ok(dag)
+    }
+
+    /// Create a new `Graph` by mapping node and edge weights to new values.
+    ///
+    /// The resulting graph has the same structure and the same graph indices as `self`.
+    pub fn map<'a, F, G, N2, E2>(&'a self, node_map: F, edge_map: G) -> Dag<N2, E2, Ix>
+    where
+        F: FnMut(NodeIndex<Ix>, &'a N) -> N2,
+        G: FnMut(EdgeIndex<Ix>, &'a E) -> E2,
+    {
+        let graph = self.graph.map(node_map, edge_map);
+        let cycle_state = self.cycle_state.clone();
+        Dag {
+            graph: graph,
+            cycle_state: cycle_state,
+        }
+    }
+
+    /// Create a new `Dag` by mapping node and edge weights. A node or edge may be mapped to `None`
+    /// to exclude it from the resulting `Dag`.
+    ///
+    /// Nodes are mapped first with the `node_map` closure, then `edge_map` is called for the edges
+    /// that have not had any endpoint removed.
+    ///
+    /// The resulting graph has the structure of a subgraph of the original graph. If no noodes are
+    /// removed, the resulting graph has compatible node indices.
+    ///
+    /// If neither nodes nor edges are removed, the resulting graph has compatible node indices. If
+    /// neither nodes nor edges are removed the result has the same graph indices as `self`.
+    ///
+    /// The resulting graph has the same structure and the same graph indices as `self`.
+    pub fn filter_map<'a, F, G, N2, E2>(&'a self, node_map: F, edge_map: G) -> Dag<N2, E2, Ix>
+    where
+        F: FnMut(NodeIndex<Ix>, &'a N) -> Option<N2>,
+        G: FnMut(EdgeIndex<Ix>, &'a E) -> Option<E2>,
+    {
+        let graph = self.graph.filter_map(node_map, edge_map);
+        let cycle_state = DfsSpace::new(&graph);
+        Dag {
+            graph: graph,
+            cycle_state: cycle_state,
         }
     }
 
@@ -130,17 +254,19 @@ impl<N, E, Ix> Dag<N, E, Ix> where Ix: IndexType {
         self.graph.edge_count()
     }
 
-    /// Borrow the `Dag`'s underlying `PetGraph<N, Ix>`.
-    /// All existing indices may be used to index into this `PetGraph` the same way they may be
+    /// Borrow the `Dag`'s underlying `DiGraph<N, Ix>`.
+    ///
+    /// All existing indices may be used to index into this `DiGraph` the same way they may be
     /// used to index into the `Dag`.
-    pub fn graph(&self) -> &PetGraph<N, E, Ix> {
+    pub fn graph(&self) -> &DiGraph<N, E, Ix> {
         &self.graph
     }
 
-    /// Take ownership of the `Dag` and return the internal `PetGraph`.
-    /// All existing indices may be used to index into this `PetGraph` the same way they may be
+    /// Take ownership of the `Dag` and return the internal `DiGraph`.
+    ///
+    /// All existing indices may be used to index into this `DiGraph` the same way they may be
     /// used to index into the `Dag`.
-    pub fn into_graph(self) -> PetGraph<N, E, Ix> {
+    pub fn into_graph(self) -> DiGraph<N, E, Ix> {
         let Dag { graph, .. } = self;
         graph
     }
@@ -186,9 +312,12 @@ impl<N, E, Ix> Dag<N, E, Ix> where Ix: IndexType {
     /// **Panics** if either `a` or `b` do not exist within the **Dag**.
     ///
     /// **Panics** if the Graph is at the maximum number of edges for its index type.
-    pub fn add_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>, weight: E)
-        -> Result<EdgeIndex<Ix>, WouldCycle<E>>
-    {
+    pub fn add_edge(
+        &mut self,
+        a: NodeIndex<Ix>,
+        b: NodeIndex<Ix>,
+        weight: E,
+    ) -> Result<EdgeIndex<Ix>, WouldCycle<E>> {
         let should_check_for_cycle = must_check_for_cycle(self, a, b);
         let state = Some(&mut self.cycle_state);
         if should_check_for_cycle && has_path_connecting(&self.graph, b, a, state) {
@@ -229,8 +358,9 @@ impl<N, E, Ix> Dag<N, E, Ix> where Ix: IndexType {
     ///  (./struct.Dag.html#method.add_parent) methods instead for greater convenience.
     ///
     /// **Panics** if the Graph is at the maximum number of nodes for its index type.
-    pub fn add_edges<I>(&mut self, edges: I) -> Result<EdgeIndices<Ix>, WouldCycle<Vec<E>>> where
-        I: IntoIterator<Item=(NodeIndex<Ix>, NodeIndex<Ix>, E)>,
+    pub fn add_edges<I>(&mut self, edges: I) -> Result<EdgeIndices<Ix>, WouldCycle<Vec<E>>>
+    where
+        I: IntoIterator<Item = (NodeIndex<Ix>, NodeIndex<Ix>, E)>,
     {
         let mut num_edges = 0;
         let mut should_check_for_cycle = false;
@@ -248,18 +378,20 @@ impl<N, E, Ix> Dag<N, E, Ix> where Ix: IndexType {
         }
 
         let total_edges = self.edge_count();
-        let new_edges_range = total_edges-num_edges..total_edges;
+        let new_edges_range = total_edges - num_edges..total_edges;
 
         // Check if adding the edges has created a cycle.
-        if should_check_for_cycle &&
-            pg::algo::is_cyclic_directed(&self.graph) {
+        if should_check_for_cycle && pg::algo::is_cyclic_directed(&self.graph) {
             let removed_edges = new_edges_range.rev().filter_map(|i| {
                 let idx = EdgeIndex::new(i);
                 self.graph.remove_edge(idx)
             });
             Err(WouldCycle(removed_edges.collect()))
         } else {
-            Ok(EdgeIndices { indices: new_edges_range, _phantom: ::std::marker::PhantomData, })
+            Ok(EdgeIndices {
+                indices: new_edges_range,
+                _phantom: std::marker::PhantomData,
+            })
         }
     }
 
@@ -282,9 +414,12 @@ impl<N, E, Ix> Dag<N, E, Ix> where Ix: IndexType {
     /// method instead for greater convenience.
     ///
     /// **Panics** if the Graph is at the maximum number of nodes for its index type.
-    pub fn update_edge(&mut self, a: NodeIndex<Ix>, b: NodeIndex<Ix>, weight: E)
-        -> Result<EdgeIndex<Ix>, WouldCycle<E>>
-    {
+    pub fn update_edge(
+        &mut self,
+        a: NodeIndex<Ix>,
+        b: NodeIndex<Ix>,
+        weight: E,
+    ) -> Result<EdgeIndex<Ix>, WouldCycle<E>> {
         if let Some(edge_idx) = self.find_edge(a, b) {
             if let Some(edge) = self.edge_weight_mut(edge_idx) {
                 *edge = weight;
@@ -313,6 +448,7 @@ impl<N, E, Ix> Dag<N, E, Ix> where Ix: IndexType {
     }
 
     /// Add a new edge and parent node to the node at the given `NodeIndex`.
+    ///
     /// Returns both the edge's `EdgeIndex` and the node's `NodeIndex`.
     ///
     /// node -> edge -> child
@@ -326,9 +462,12 @@ impl<N, E, Ix> Dag<N, E, Ix> where Ix: IndexType {
     /// **Panics** if the given child node doesn't exist.
     ///
     /// **Panics** if the Graph is at the maximum number of edges for its index.
-    pub fn add_parent(&mut self, child: NodeIndex<Ix>, edge: E, node: N)
-        -> (EdgeIndex<Ix>, NodeIndex<Ix>)
-    {
+    pub fn add_parent(
+        &mut self,
+        child: NodeIndex<Ix>,
+        edge: E,
+        node: N,
+    ) -> (EdgeIndex<Ix>, NodeIndex<Ix>) {
         let parent_node = self.graph.add_node(node);
         let parent_edge = self.graph.add_edge(parent_node, child, edge);
         (parent_edge, parent_node)
@@ -348,9 +487,12 @@ impl<N, E, Ix> Dag<N, E, Ix> where Ix: IndexType {
     /// **Panics** if the given parent node doesn't exist.
     ///
     /// **Panics** if the Graph is at the maximum number of edges for its index.
-    pub fn add_child(&mut self, parent: NodeIndex<Ix>, edge: E, node: N)
-        -> (EdgeIndex<Ix>, NodeIndex<Ix>)
-    {
+    pub fn add_child(
+        &mut self,
+        parent: NodeIndex<Ix>,
+        edge: E,
+        node: N,
+    ) -> (EdgeIndex<Ix>, NodeIndex<Ix>) {
         let child_node = self.graph.add_node(node);
         let child_edge = self.graph.add_edge(parent, child_node, edge);
         (child_edge, child_node)
@@ -401,14 +543,20 @@ impl<N, E, Ix> Dag<N, E, Ix> where Ix: IndexType {
     }
 
     /// Index the `Dag` by two indices.
-    /// 
+    ///
     /// Both indices can be either `NodeIndex`s, `EdgeIndex`s or a combination of the two.
     ///
     /// **Panics** if the indices are equal or if they are out of bounds.
-    pub fn index_twice_mut<A, B>(&mut self, a: A, b: B)
-        -> (&mut <PetGraph<N, E, Ix> as Index<A>>::Output,
-            &mut <PetGraph<N, E, Ix> as Index<B>>::Output) where
-        PetGraph<N, E, Ix>: IndexMut<A> + IndexMut<B>,
+    pub fn index_twice_mut<A, B>(
+        &mut self,
+        a: A,
+        b: B,
+    ) -> (
+        &mut <DiGraph<N, E, Ix> as Index<A>>::Output,
+        &mut <DiGraph<N, E, Ix> as Index<B>>::Output,
+    )
+    where
+        DiGraph<N, E, Ix>: IndexMut<A> + IndexMut<B>,
         A: GraphIndex,
         B: GraphIndex,
     {
@@ -423,7 +571,7 @@ impl<N, E, Ix> Dag<N, E, Ix> where Ix: IndexType {
     }
 
     /// Remove an edge and return its weight, or `None` if it didn't exist.
-    /// 
+    ///
     /// Computes in **O(e')** time, where **e'** is the size of four particular edge lists, for the
     /// nodes of **e** and the nodes of another affected edge.
     pub fn remove_edge(&mut self, e: EdgeIndex<Ix>) -> Option<E> {
@@ -469,93 +617,350 @@ impl<N, E, Ix> Dag<N, E, Ix> where Ix: IndexType {
     /// A **Walker** type that recursively walks the **Dag** using the given `recursive_fn`.
     ///
     /// See the [**Walker**](./walker/trait.Walker.html) trait for more useful methods.
-    pub fn recursive_walk<F>(&self, start: NodeIndex<Ix>, recursive_fn: F)
-        -> RecursiveWalk<N, E, Ix, F>
-        where F: FnMut(&Self, NodeIndex<Ix>) -> Option<(EdgeIndex<Ix>, NodeIndex<Ix>)>
+    pub fn recursive_walk<F>(
+        &self,
+        start: NodeIndex<Ix>,
+        recursive_fn: F,
+    ) -> RecursiveWalk<N, E, Ix, F>
+    where
+        F: FnMut(&Self, NodeIndex<Ix>) -> Option<(EdgeIndex<Ix>, NodeIndex<Ix>)>,
     {
         walker::Recursive::new(start, recursive_fn)
     }
-
 }
-
 
 /// After adding a new edge to the graph, we use this function immediately after to check whether
 /// or not we need to check for a cycle.
-/// 
+///
 /// If our parent *a* has no parents or our child *b* has no children, or if there was already an
 /// edge connecting *a* to *b*, we know that adding this edge has not caused the graph to cycle.
 fn must_check_for_cycle<N, E, Ix>(dag: &Dag<N, E, Ix>, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> bool
-    where Ix: IndexType,
+where
+    Ix: IndexType,
 {
-    dag.parents(a).next(dag).is_some() && dag.children(b).next(dag).is_some()
-    && dag.find_edge(a, b).is_none()
+    dag.parents(a).walk_next(dag).is_some() && dag.children(b).walk_next(dag).is_some()
+        && dag.find_edge(a, b).is_none()
 }
 
+// Dag implementations.
 
-impl<N, E, Ix> Index<NodeIndex<Ix>> for Dag<N, E, Ix> where Ix: IndexType {
+impl<N, E, Ix> Into<DiGraph<N, E, Ix>> for Dag<N, E, Ix>
+where
+    Ix: IndexType,
+{
+    fn into(self) -> DiGraph<N, E, Ix> {
+        self.into_graph()
+    }
+}
+
+impl<N, E, Ix> Default for Dag<N, E, Ix>
+where
+    Ix: IndexType,
+{
+    fn default() -> Self {
+        Dag::new()
+    }
+}
+
+#[cfg(feature = "serde-1")]
+impl<N, E, Ix> Serialize for Dag<N, E, Ix>
+where
+    N: Serialize,
+    E: Serialize,
+    Ix: IndexType + Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.graph.serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde-1")]
+impl<'de, N, E, Ix> Deserialize<'de> for Dag<N, E, Ix>
+where
+    Self: Sized,
+    N: Deserialize<'de>,
+    E: Deserialize<'de>,
+    Ix: IndexType + Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let graph = Deserialize::deserialize(deserializer)?;
+        let cycle_state = DfsSpace::new(&graph);
+        let dag = Dag {
+            graph: graph,
+            cycle_state: cycle_state,
+        };
+        Ok(dag)
+    }
+}
+
+impl<N, E, Ix> GraphBase for Dag<N, E, Ix>
+where
+    Ix: IndexType,
+{
+    type NodeId = NodeIndex<Ix>;
+    type EdgeId = EdgeIndex<Ix>;
+}
+
+impl<N, E, Ix> NodeCount for Dag<N, E, Ix>
+where
+    Ix: IndexType,
+{
+    fn node_count(&self) -> usize {
+        Dag::node_count(self)
+    }
+}
+
+impl<N, E, Ix> GraphProp for Dag<N, E, Ix>
+where
+    Ix: IndexType,
+{
+    type EdgeType = pg::Directed;
+    fn is_directed(&self) -> bool {
+        true
+    }
+}
+
+impl<N, E, Ix> pg::visit::Visitable for Dag<N, E, Ix>
+where
+    Ix: IndexType,
+{
+    type Map = <DiGraph<N, E, Ix> as Visitable>::Map;
+    fn visit_map(&self) -> Self::Map {
+        self.graph.visit_map()
+    }
+    fn reset_map(&self, map: &mut Self::Map) {
+        self.graph.reset_map(map)
+    }
+}
+
+impl<N, E, Ix> pg::visit::Data for Dag<N, E, Ix>
+where
+    Ix: IndexType,
+{
+    type NodeWeight = N;
+    type EdgeWeight = E;
+}
+
+impl<N, E, Ix> pg::data::DataMap for Dag<N, E, Ix>
+where
+    Ix: IndexType,
+{
+    fn node_weight(&self, id: Self::NodeId) -> Option<&Self::NodeWeight> {
+        self.graph.node_weight(id)
+    }
+    fn edge_weight(&self, id: Self::EdgeId) -> Option<&Self::EdgeWeight> {
+        self.graph.edge_weight(id)
+    }
+}
+
+impl<N, E, Ix> pg::data::DataMapMut for Dag<N, E, Ix>
+where
+    Ix: IndexType,
+{
+    fn node_weight_mut(&mut self, id: Self::NodeId) -> Option<&mut Self::NodeWeight> {
+        self.graph.node_weight_mut(id)
+    }
+    fn edge_weight_mut(&mut self, id: Self::EdgeId) -> Option<&mut Self::EdgeWeight> {
+        self.graph.edge_weight_mut(id)
+    }
+}
+
+impl<'a, N, E, Ix> IntoNeighbors for &'a Dag<N, E, Ix>
+where
+    Ix: IndexType,
+{
+    type Neighbors = pg::graph::Neighbors<'a, E, Ix>;
+    fn neighbors(self, n: NodeIndex<Ix>) -> Self::Neighbors {
+        self.graph.neighbors(n)
+    }
+}
+
+impl<'a, N, E, Ix> IntoNeighborsDirected for &'a Dag<N, E, Ix>
+where
+    Ix: IndexType,
+{
+    type NeighborsDirected = pg::graph::Neighbors<'a, E, Ix>;
+    fn neighbors_directed(self, n: NodeIndex<Ix>, d: pg::Direction) -> Self::Neighbors {
+        self.graph.neighbors_directed(n, d)
+    }
+}
+
+impl<'a, N, E, Ix> IntoEdgeReferences for &'a Dag<N, E, Ix>
+where
+    Ix: IndexType,
+{
+    type EdgeRef = pg::graph::EdgeReference<'a, E, Ix>;
+    type EdgeReferences = pg::graph::EdgeReferences<'a, E, Ix>;
+    fn edge_references(self) -> Self::EdgeReferences {
+        self.graph.edge_references()
+    }
+}
+
+impl<'a, N, E, Ix> IntoEdges for &'a Dag<N, E, Ix>
+where
+    Ix: IndexType,
+{
+    type Edges = Edges<'a, E, Ix>;
+    fn edges(self, a: Self::NodeId) -> Self::Edges {
+        self.graph.edges(a)
+    }
+}
+
+impl<'a, N, E, Ix> IntoEdgesDirected for &'a Dag<N, E, Ix>
+where
+    Ix: IndexType,
+{
+    type EdgesDirected = Edges<'a, E, Ix>;
+    fn edges_directed(self, a: Self::NodeId, dir: pg::Direction) -> Self::EdgesDirected {
+        self.graph.edges_directed(a, dir)
+    }
+}
+
+impl<'a, N, E, Ix> IntoNodeIdentifiers for &'a Dag<N, E, Ix>
+where
+    Ix: IndexType,
+{
+    type NodeIdentifiers = pg::graph::NodeIndices<Ix>;
+    fn node_identifiers(self) -> Self::NodeIdentifiers {
+        self.graph.node_identifiers()
+    }
+}
+
+impl<'a, N, E, Ix> IntoNodeReferences for &'a Dag<N, E, Ix>
+where
+    Ix: IndexType,
+{
+    type NodeRef = (NodeIndex<Ix>, &'a N);
+    type NodeReferences = pg::graph::NodeReferences<'a, N, Ix>;
+    fn node_references(self) -> Self::NodeReferences {
+        self.graph.node_references()
+    }
+}
+
+impl<N, E, Ix> NodeIndexable for Dag<N, E, Ix>
+where
+    Ix: IndexType,
+{
+    fn node_bound(&self) -> usize {
+        self.graph.node_bound()
+    }
+    fn to_index(&self, ix: NodeIndex<Ix>) -> usize {
+        self.graph.to_index(ix)
+    }
+    fn from_index(&self, ix: usize) -> Self::NodeId {
+        self.graph.from_index(ix)
+    }
+}
+
+impl<N, E, Ix> NodeCompactIndexable for Dag<N, E, Ix>
+where
+    Ix: IndexType,
+{
+}
+
+impl<N, E, Ix> Index<NodeIndex<Ix>> for Dag<N, E, Ix>
+where
+    Ix: IndexType,
+{
     type Output = N;
     fn index(&self, index: NodeIndex<Ix>) -> &N {
         &self.graph[index]
     }
 }
 
-impl<N, E, Ix> IndexMut<NodeIndex<Ix>> for Dag<N, E, Ix> where Ix: IndexType {
+impl<N, E, Ix> IndexMut<NodeIndex<Ix>> for Dag<N, E, Ix>
+where
+    Ix: IndexType,
+{
     fn index_mut(&mut self, index: NodeIndex<Ix>) -> &mut N {
         &mut self.graph[index]
     }
 }
 
-impl<N, E, Ix> Index<EdgeIndex<Ix>> for Dag<N, E, Ix> where Ix: IndexType {
+impl<N, E, Ix> Index<EdgeIndex<Ix>> for Dag<N, E, Ix>
+where
+    Ix: IndexType,
+{
     type Output = E;
     fn index(&self, index: EdgeIndex<Ix>) -> &E {
         &self.graph[index]
     }
 }
 
-impl<N, E, Ix> IndexMut<EdgeIndex<Ix>> for Dag<N, E, Ix> where Ix: IndexType {
+impl<N, E, Ix> IndexMut<EdgeIndex<Ix>> for Dag<N, E, Ix>
+where
+    Ix: IndexType,
+{
     fn index_mut(&mut self, index: EdgeIndex<Ix>) -> &mut E {
         &mut self.graph[index]
     }
 }
 
-
-impl<N, E, Ix> Walker<Dag<N, E, Ix>> for Children<N, E, Ix>
-    where Ix: IndexType,
+impl<N, E, Ix> GetAdjacencyMatrix for Dag<N, E, Ix>
+where
+    Ix: IndexType,
 {
-    type Index = Ix;
+    type AdjMatrix = <DiGraph<N, E, Ix> as GetAdjacencyMatrix>::AdjMatrix;
+    fn adjacency_matrix(&self) -> Self::AdjMatrix {
+        self.graph.adjacency_matrix()
+    }
+    fn is_adjacent(&self, matrix: &Self::AdjMatrix, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> bool {
+        self.graph.is_adjacent(matrix, a, b)
+    }
+}
+
+impl<'a, N, E, Ix> Walker<&'a Dag<N, E, Ix>> for Children<N, E, Ix>
+where
+    Ix: IndexType,
+{
+    type Item = (EdgeIndex<Ix>, NodeIndex<Ix>);
     #[inline]
-    fn next(&mut self, dag: &Dag<N, E, Ix>) -> Option<(EdgeIndex<Ix>, NodeIndex<Ix>)> {
+    fn walk_next(&mut self, dag: &'a Dag<N, E, Ix>) -> Option<Self::Item> {
         self.walk_edges.next(&dag.graph)
     }
 }
 
-impl<N, E, Ix> Walker<Dag<N, E, Ix>> for Parents<N, E, Ix>
-    where Ix: IndexType,
+impl<'a, N, E, Ix> Walker<&'a Dag<N, E, Ix>> for Parents<N, E, Ix>
+where
+    Ix: IndexType,
 {
-    type Index = Ix;
+    type Item = (EdgeIndex<Ix>, NodeIndex<Ix>);
     #[inline]
-    fn next(&mut self, dag: &Dag<N, E, Ix>) -> Option<(EdgeIndex<Ix>, NodeIndex<Ix>)> {
+    fn walk_next(&mut self, dag: &'a Dag<N, E, Ix>) -> Option<Self::Item> {
         self.walk_edges.next(&dag.graph)
     }
 }
 
-
-impl<Ix> Iterator for EdgeIndices<Ix> where Ix: IndexType {
+impl<Ix> Iterator for EdgeIndices<Ix>
+where
+    Ix: IndexType,
+{
     type Item = EdgeIndex<Ix>;
     fn next(&mut self) -> Option<EdgeIndex<Ix>> {
         self.indices.next().map(|i| EdgeIndex::new(i))
     }
 }
 
+impl<E> std::fmt::Debug for WouldCycle<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        writeln!(f, "WouldCycle")
+    }
+}
 
-impl<E> ::std::fmt::Display for WouldCycle<E> where E: ::std::fmt::Debug {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
+impl<E> std::fmt::Display for WouldCycle<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         writeln!(f, "{:?}", self)
     }
 }
 
-impl<E> ::std::error::Error for WouldCycle<E> where E: ::std::fmt::Debug + ::std::any::Any {
+impl<E> std::error::Error for WouldCycle<E> {
     fn description(&self) -> &str {
-        "Adding this input would have caused the graph to cycle!"
+        "Adding this edge would have created a cycle"
     }
 }

--- a/src/walker.rs
+++ b/src/walker.rs
@@ -1,346 +1,26 @@
 //! **Walker** is a trait providing a variety of useful methods for traversing graph types.
 
-
-use ::{EdgeIndex, NodeIndex};
-use petgraph::graph::IndexType;
+use petgraph::visit::{GraphBase, GraphRef, Walker};
 use std::marker::PhantomData;
-use std::ops::Index;
-
-
-/// Short-hand for an edge node index pair.
-pub type IndexPair<Ix> = (EdgeIndex<Ix>, NodeIndex<Ix>);
-
-
-/// A trait providing a variety of useful methods for traversing some graph type **G**.
-///
-/// **Walker** can be likened to the std **Iterator** trait. It's methods behave similarly, but it
-/// is different in that it takes a reference to some graph as an argument to its "next" method.
-///
-/// **Walker** method return types (besides the iterators) never borrow the graph. This means that
-/// we can still safely mutably borrow from the graph whilst we traverse it.
-pub trait Walker<G> {
-    /// The unsigned integer type used for node and edge indices.
-    type Index: IndexType;
-
-    /// Fetch the `EdgeIndex` and `NodeIndex` to the next neighbour in our walk through the given
-    /// **Graph**.
-    fn next(&mut self, graph: &G) -> Option<IndexPair<Self::Index>>;
-
-    /// The next edge in our walk for the given **Graph**.
-    #[inline]
-    fn next_edge(&mut self, graph: &G) -> Option<EdgeIndex<Self::Index>> {
-        self.next(graph).map(|(e, _)| e)
-    }
-
-    /// The next node in our walk for the given **Graph**.
-    #[inline]
-    fn next_node(&mut self, graph: &G) -> Option<NodeIndex<Self::Index>> {
-        self.next(graph).map(|(_, n)| n)
-    }
-
-    /// Counts all the steps in the entire walk of the given graph.
-    #[inline]
-    fn count(mut self, graph: &G) -> usize where Self: Sized {
-        let mut count = 0;
-        while let Some(_) = self.next(graph) {
-            count += 1;
-        }
-        count
-    }
-
-    /// Walks the whole walk until reaching and returning the last edge node pair.
-    #[inline]
-    fn last(mut self, graph: &G) -> Option<IndexPair<Self::Index>> where Self: Sized {
-        let mut maybe_last_pair = None;
-        while let Some(pair) = self.next(graph) {
-            maybe_last_pair = Some(pair);
-        }
-        maybe_last_pair
-    }
-
-    /// Walks the whole walk until reaching and returning the last edge.
-    #[inline]
-    fn last_edge(self, graph: &G) -> Option<EdgeIndex<Self::Index>> where Self: Sized {
-        self.last(graph).map(|(e, _)| e)
-    }
-
-    /// Walks the whole walk until reaching and returning the last node.
-    #[inline]
-    fn last_node(self, graph: &G) -> Option<NodeIndex<Self::Index>> where Self: Sized {
-        self.last(graph).map(|(_, n)| n)
-    }
-
-    /// Walks "n" number of steps and produces the resulting edge node pair.
-    #[inline]
-    fn nth(mut self, graph: &G, n: usize) -> Option<IndexPair<Self::Index>>
-        where Self: Sized
-    {
-        (0..n+1)
-            .map(|_| self.next(graph))
-            .nth(n)
-            .and_then(|maybe_pair| maybe_pair)
-    }
-
-    /// Walks "n" number of steps and produces the resulting edge.
-    #[inline]
-    fn nth_edge(self, graph: &G, n: usize) -> Option<EdgeIndex<Self::Index>>
-        where Self: Sized
-    {
-        self.nth(graph, n).map(|(e, _)| e)
-    }
-
-    /// Walks "n" number of steps and produces the resulting node.
-    #[inline]
-    fn nth_node(self, graph: &G, n: usize) -> Option<NodeIndex<Self::Index>>
-        where Self: Sized
-    {
-        self.nth(graph, n).map(|(_, n)| n)
-    }
-
-    /// Produces a walker that will walk the entirey of `self` before walking the entirey of other.
-    #[inline]
-    fn chain<O>(self, other: O) -> Chain<G, Self::Index, Self, O>
-        where Self: Sized,
-              O: Walker<G, Index=Self::Index>,
-    {
-        Chain {
-            a: Some(self),
-            b: other,
-            _graph: PhantomData,
-            _index: PhantomData,
-        }
-    }
-
-    /// Creates a walker that applies the predicate to each element returned by this walker.
-    /// The only elements that will be yielded are those that make the predicate evaluate to true.
-    #[inline]
-    fn filter<P>(self, predicate: P) -> Filter<Self, P>
-        where Self: Sized,
-              P: FnMut(&G, EdgeIndex<Self::Index>, NodeIndex<Self::Index>) -> bool,
-    {
-        Filter {
-            walker: self,
-            predicate: predicate,
-        }
-    }
-
-    /// Creates a walker that has a `.peek(&graph)` method that returns an optional next neighbor.
-    #[inline]
-    fn peekable(self) -> Peekable<G, Self::Index, Self> where Self: Sized {
-        Peekable {
-            walker: self,
-            maybe_next: None,
-            _graph: PhantomData,
-        }
-    }
-
-    /// Creates a walker that invokes the predicate on elements until it returns false. Once the
-    /// predicate returns false, that element and all further elements are yielded.
-    #[inline]
-    fn skip_while<P>(self, predicate: P) -> SkipWhile<Self, P>
-        where Self: Sized,
-              P: FnMut(&G, EdgeIndex<Self::Index>, NodeIndex<Self::Index>) -> bool,
-    {
-        SkipWhile {
-            walker: self,
-            maybe_predicate: Some(predicate),
-        }
-    }
-
-    /// Creates a walker that yields elements so long as the predicate returns true. After the
-    /// predicate returns false for the first time, no further elements will be yielded.
-    #[inline]
-    fn take_while<P>(self, predicate: P) -> TakeWhile<Self, P>
-        where Self: Sized,
-              P: FnMut(&G, EdgeIndex<Self::Index>, NodeIndex<Self::Index>) -> bool,
-    {
-        TakeWhile {
-            maybe_walker: Some(self),
-            predicate: predicate,
-        }
-    }
-
-    /// Creates a walker that skips the first n steps of this walk, and then yields all further
-    /// steps.
-    #[inline]
-    fn skip(self, n: usize) -> Skip<G, Self::Index, Self> where Self: Sized {
-        Skip {
-            walker: self,
-            to_skip: n,
-            _graph: PhantomData,
-            _index: PhantomData,
-        }
-    }
-
-    /// Creates a walker that yields the first n steps of this walk.
-    #[inline]
-    fn take(self, n: usize) -> Take<G, Self::Index, Self> where Self: Sized {
-        Take {
-            walker: self,
-            to_take: n,
-            _graph: PhantomData,
-            _index: PhantomData,
-        }
-    }
-
-    /// Tests whether the predicate holds true for all steps in the walk.
-    #[inline]
-    fn all<P>(&mut self, graph: &G, mut predicate: P) -> bool
-        where P: FnMut(&G, EdgeIndex<Self::Index>, NodeIndex<Self::Index>) -> bool,
-    {
-        while let Some((e, n)) = self.next(graph) {
-            if !predicate(graph, e, n) {
-                return false;
-            }
-        }
-        true
-    }
-
-    /// Tests whether any step in the walk satisfies the given predicate.
-    ///
-    /// Does not step the walker past the first found step.
-    #[inline]
-    fn any<P>(&mut self, graph: &G, mut predicate: P) -> bool
-        where P: FnMut(&G, EdgeIndex<Self::Index>, NodeIndex<Self::Index>) -> bool,
-    {
-        while let Some((e, n)) = self.next(graph) {
-            if predicate(graph, e, n) {
-                return true;
-            }
-        }
-        false
-    }
-
-    /// Returns the first edge node index pair satisfying the specified predicate.
-    /// 
-    /// Does not consume the walker past the first found step.
-    #[inline]
-    fn find<P>(&mut self, graph: &G, mut predicate: P) -> Option<IndexPair<Self::Index>>
-        where P: FnMut(&G, EdgeIndex<Self::Index>, NodeIndex<Self::Index>) -> bool
-    {
-        while let Some((e, n)) = self.next(graph) {
-            if predicate(graph, e, n) {
-                return Some((e, n));
-            }
-        }
-        None
-    }
-
-    /// Returns the edge index satisfying the specified predicate.
-    /// 
-    /// Does not consume the walker past the first found step.
-    #[inline]
-    fn find_edge<P>(&mut self, graph: &G, predicate: P) -> Option<EdgeIndex<Self::Index>>
-        where P: FnMut(&G, EdgeIndex<Self::Index>, NodeIndex<Self::Index>) -> bool
-    {
-        self.find(graph, predicate).map(|(e, _)| e)
-    }
-
-    /// Returns the node index satisfying the specified predicate.
-    /// 
-    /// Does not consume the walker past the first found step.
-    #[inline]
-    fn find_node<P>(&mut self, graph: &G, predicate: P) -> Option<NodeIndex<Self::Index>>
-        where P: FnMut(&G, EdgeIndex<Self::Index>, NodeIndex<Self::Index>) -> bool
-    {
-        self.find(graph, predicate).map(|(_, n)| n)
-    }
-
-    /// Repeats the walker endlessly.
-    #[inline]
-    fn cycle(self) -> Cycle<G, Self::Index, Self> where Self: Clone + Sized {
-        let clone = self.clone();
-        Cycle {
-            walker: self,
-            clone: clone,
-            _graph: PhantomData,
-            _index: PhantomData,
-        }
-    }
-
-    /// Performs a fold operation over the entire walker, returning the eventual state at the end
-    /// of the walk.
-    /// 
-    /// This operation is sometimes called 'reduce' or 'inject'.
-    #[inline]
-    fn fold<B, F>(mut self, init: B, graph: &G, mut f: F) -> B
-        where Self: Sized,
-              F: FnMut(B, &G, EdgeIndex<Self::Index>, NodeIndex<Self::Index>) -> B
-    {
-        let mut accum = init;
-        while let Some((e, n)) = self.next(graph) {
-            accum = f(accum, graph, e, n);
-        }
-        accum
-    }
-
-    /// Creates a walker that calls a function with a reference to each index pair before yielding
-    /// them. This is often useful for debugging a walker pipeline.
-    #[inline]
-    fn inspect<F>(self, f: F) -> Inspect<Self, F>
-        where Self: Sized,
-              F: FnMut(&G, EdgeIndex<Self::Index>, NodeIndex<Self::Index>),
-    {
-        Inspect {
-            walker: self,
-            f: f,
-        }
-    }
-
-    /// Converts the walker into an iterator yielding index pairs.
-    ///
-    /// The returned iterator borrows the graph.
-    #[inline]
-    fn iter(self, graph: &G) -> Iter<G, Self::Index, Self>
-        where Self: Sized,
-    {
-        Iter {
-            walker: self,
-            graph: graph,
-            _index: PhantomData,
-        }
-    }
-
-    /// Converts the walker into an iterator yielding `(&e, &n)`, where `e` is the edge weight for
-    /// the next `EdgeIndex` and `n` is the node weight for the next `NodeIndex`.
-    ///
-    /// The returned iterator borrows the graph.
-    #[inline]
-    fn iter_weights(self, graph: &G) -> IterWeights<G, Self::Index, Self>
-        where Self: Sized,
-    {
-        IterWeights {
-            walker: self,
-            graph: graph,
-            _index: PhantomData,
-        }
-    }
-
-}
-
-
-// /// The **Walker** synonym to the **std::iter::once** function.
-// ///
-// /// Returns a walker that takes just one step, yielding the given index pair.
-// pub fn once<Ix>(e: EdgeIndex<Ix>, n: NodeIndex<Ix>) -> Once<Ix> {
-// }
-
 
 /// Recursively walks a graph using the recursive function `recursive_fn`.
 #[derive(Clone, Debug)]
-pub struct Recursive<G, Ix, F> {
-    next: NodeIndex<Ix>,
+pub struct Recursive<G, F>
+where
+    G: GraphBase,
+{
+    next: G::NodeId,
     recursive_fn: F,
     _graph: PhantomData<G>,
 }
 
-impl<G, Ix, F> Recursive<G, Ix, F> {
-
+impl<G, F> Recursive<G, F>
+where
+    G: GraphBase,
+    F: FnMut(&G, G::NodeId) -> Option<(G::EdgeId, G::NodeId)>,
+{
     /// Construct a new **Recursive** **Walker** starting from the node at the given index.
-    pub fn new(start: NodeIndex<Ix>, recursive_fn: F) -> Self
-        where Ix: IndexType,
-              F: FnMut(&G, NodeIndex<Ix>) -> Option<IndexPair<Ix>>,
-    {
+    pub fn new(start: G::NodeId, recursive_fn: F) -> Self {
         Recursive {
             next: start,
             recursive_fn: recursive_fn,
@@ -348,187 +28,263 @@ impl<G, Ix, F> Recursive<G, Ix, F> {
         }
     }
 
-}
-
-impl<G, Ix, F> Walker<G> for Recursive<G, Ix, F>
-    where Ix: IndexType,
-          F: FnMut(&G, NodeIndex<Ix>) -> Option<IndexPair<Ix>>,
-{
-    type Index = Ix;
-    #[inline]
-    fn next(&mut self, graph: &G) -> Option<IndexPair<Ix>> {
-        let Recursive { ref mut next, ref mut recursive_fn, .. } = *self;
-        recursive_fn(graph, *next).map(|(e, n)| {
+    /// Yield the next recursion step.
+    pub fn next(&mut self, g: &G) -> Option<(G::EdgeId, G::NodeId)> {
+        let Recursive {
+            ref mut next,
+            ref mut recursive_fn,
+            ..
+        } = *self;
+        recursive_fn(g, *next).map(|(e, n)| {
             *next = n;
             (e, n)
         })
     }
 }
 
+impl<'a, G, F> Walker<&'a G> for Recursive<G, F>
+where
+    G: GraphBase,
+    F: FnMut(&G, G::NodeId) -> Option<(G::EdgeId, G::NodeId)>,
+{
+    type Item = (G::EdgeId, G::NodeId);
+    #[inline]
+    fn walk_next(&mut self, g: &G) -> Option<Self::Item> {
+        self.next(g)
+    }
+}
 
 /// Walks the entirety of `a` before walking the entirety of `b`.
 #[derive(Clone, Debug)]
-pub struct Chain<G, Ix, A, B> {
+pub struct Chain<G, A, B> {
     a: Option<A>,
     b: B,
     _graph: PhantomData<G>,
-    _index: PhantomData<Ix>,
 }
 
-
-impl<G, Ix, A, B> Walker<G> for Chain<G, Ix, A, B>
-    where Ix: IndexType,
-          A: Walker<G, Index=Ix>,
-          B: Walker<G, Index=Ix>,
-{
-    type Index = Ix;
-    #[inline]
-    fn next(&mut self, graph: &G) -> Option<IndexPair<Ix>> {
-        let Chain { ref mut a, ref mut b, .. } = *self;
-        match a.as_mut().and_then(|walker| walker.next(graph)) {
-            Some(step) => Some(step),
-            None => {
-                *a = None;
-                b.next(graph)
-            },
+impl<G, A, B> Chain<G, A, B> {
+    /// Create a new `Chain`.
+    pub fn new(a: A, b: B) -> Self {
+        Chain {
+            a: Some(a),
+            b,
+            _graph: PhantomData,
         }
     }
 }
 
-
-/// A walker that applies some given predicate to each element returned by its walker.
-/// The only index pairs that will be yielded are those that make the predicate evaluate to true.
-#[derive(Clone, Debug)]
-pub struct Filter<W, P> {
-    walker: W,
-    predicate: P,
+impl<'a, G, A, B> Walker<&'a G> for Chain<G, A, B>
+where
+    G: GraphBase,
+    A: Walker<&'a G>,
+    B: Walker<&'a G, Item = A::Item>,
+{
+    type Item = A::Item;
+    #[inline]
+    fn walk_next(&mut self, graph: &'a G) -> Option<Self::Item> {
+        let Chain {
+            ref mut a,
+            ref mut b,
+            ..
+        } = *self;
+        match a.as_mut().and_then(|walker| walker.walk_next(graph)) {
+            Some(step) => Some(step),
+            None => {
+                *a = None;
+                b.walk_next(graph)
+            }
+        }
+    }
 }
 
+/// A walker that applies some given predicate to each element returned by its walker.
+///
+/// The only index pairs that will be yielded are those that make the predicate evaluate to true.
+#[derive(Clone, Debug)]
+pub struct Filter<G, W, P> {
+    walker: W,
+    predicate: P,
+    _graph: PhantomData<G>,
+}
 
-impl<G, Ix, W, P> Walker<G> for Filter<W, P>
-    where Ix: IndexType,
-          W: Walker<G, Index=Ix>,
-          P: FnMut(&G, EdgeIndex<Ix>, NodeIndex<Ix>) -> bool,
+impl<G, W, P> Filter<G, W, P> {
+    /// Create a new `Filter`.
+    pub fn new(walker: W, predicate: P) -> Self
+    where
+        G: GraphRef,
+        W: Walker<G>,
+        P: FnMut(G, &W::Item) -> bool,
+    {
+        Filter {
+            walker,
+            predicate,
+            _graph: PhantomData,
+        }
+    }
+}
+
+impl<G, W, P> Walker<G> for Filter<G, W, P>
+where
+    G: GraphRef,
+    W: Walker<G>,
+    P: FnMut(G, &W::Item) -> bool,
 {
-    type Index = Ix;
+    type Item = W::Item;
     #[inline]
-    fn next(&mut self, graph: &G) -> Option<IndexPair<Ix>> {
-        while let Some((e, n)) = self.walker.next(graph) {
-            if (self.predicate)(graph, e, n) {
-                return Some((e, n));
+    fn walk_next(&mut self, graph: G) -> Option<Self::Item> {
+        while let Some(item) = self.walker.walk_next(graph) {
+            if (self.predicate)(graph, &item) {
+                return Some(item);
             }
         }
         None
     }
 }
 
-
 /// A walker that has a `.peek(&graph)` method that returns an optional next neighbor.
 #[derive(Clone, Debug)]
-pub struct Peekable<G, Ix, W> where Ix: IndexType {
+pub struct Peekable<G, W>
+where
+    W: Walker<G>,
+{
     walker: W,
-    maybe_next: Option<IndexPair<Ix>>,
+    maybe_next: Option<W::Item>,
     _graph: PhantomData<G>,
 }
 
-
-impl<G, Ix, W> Peekable<G, Ix, W>
-    where Ix: IndexType,
-          W: Walker<G, Index=Ix>,
+impl<G, W> Peekable<G, W>
+where
+    G: GraphRef,
+    W: Walker<G>,
 {
+    /// Create a new `Peekable` walker.
+    pub fn new(walker: W) -> Self {
+        Peekable {
+            walker,
+            maybe_next: None,
+            _graph: PhantomData,
+        }
+    }
 
     /// The edge node index pair of the neighbor at the next step in our walk of the given graph.
     #[inline]
-    pub fn peek(&mut self, graph: &G) -> Option<IndexPair<Ix>> {
-        self.maybe_next.or_else(|| {
-            self.maybe_next = self.walker.next(graph);
-            self.maybe_next
-        })
+    pub fn peek(&mut self, graph: G) -> Option<&W::Item> {
+        if self.maybe_next.is_none() {
+            self.maybe_next = self.walker.walk_next(graph);
+        }
+        self.maybe_next.as_ref()
     }
-
-    /// The edge index of the neighbor at the next step in our walk of the given graph.
-    #[inline]
-    pub fn peek_edge(&mut self, graph: &G) -> Option<EdgeIndex<Ix>> {
-        self.peek(graph).map(|(e, _)| e)
-    }
-
-    /// The node index of the neighbor at the next step in our walk of the given graph.
-    #[inline]
-    pub fn peek_node(&mut self, graph: &G) -> Option<NodeIndex<Ix>> {
-        self.peek(graph).map(|(_, n)| n)
-    }
-
 }
 
-
-impl<G, Ix, W> Walker<G> for Peekable<G, Ix, W>
-    where Ix: IndexType,
-          W: Walker<G, Index=Ix>,
+impl<G, W> Walker<G> for Peekable<G, W>
+where
+    G: GraphRef,
+    W: Walker<G>,
 {
-    type Index = Ix;
+    type Item = W::Item;
     #[inline]
-    fn next(&mut self, graph: &G) -> Option<IndexPair<Ix>> {
-        self.maybe_next.take().or_else(|| {
-            self.walker.next(graph)
-        })
+    fn walk_next(&mut self, graph: G) -> Option<Self::Item> {
+        self.maybe_next
+            .take()
+            .or_else(|| self.walker.walk_next(graph))
     }
 }
 
-
-/// A walker that invokes the predicate on elements until it returns false. Once the predicate
-/// returns false, that element and all further elements are yielded.
+/// A walker that invokes the predicate on elements until it returns false.
+///
+/// Once the predicate returns false, that element and all further elements are yielded.
 #[derive(Clone, Debug)]
-pub struct SkipWhile<W, P> {
+pub struct SkipWhile<G, W, P> {
     walker: W,
     maybe_predicate: Option<P>,
+    _graph: PhantomData<G>,
 }
 
-
-impl<G, Ix, W, P> Walker<G> for SkipWhile<W, P>
-    where Ix: IndexType,
-          W: Walker<G, Index=Ix>,
-          P: FnMut(&G, EdgeIndex<Ix>, NodeIndex<Ix>) -> bool,
-{
-    type Index = Ix;
-    #[inline]
-    fn next(&mut self, graph: &G) -> Option<IndexPair<Ix>> {
-        match self.maybe_predicate.take() {
-            Some(mut predicate) => {
-                while let Some((e, n)) = self.walker.next(graph) {
-                    if !predicate(graph, e, n) {
-                        return Some((e, n));
-                    }
-                }
-                None
-            },
-            None => self.walker.next(graph),
+impl<G, W, P> SkipWhile<G, W, P> {
+    /// Create a new `SkipWhile` walker.
+    pub fn new(walker: W, predicate: P) -> Self
+    where
+        G: GraphRef,
+        W: Walker<G>,
+        P: FnMut(G, &W::Item) -> bool,
+    {
+        SkipWhile {
+            walker,
+            maybe_predicate: Some(predicate),
+            _graph: PhantomData,
         }
     }
 }
 
-
-/// A walker that yields elements so long as the predicate returns true. After the
-/// predicate returns false for the first time, no further elements will be yielded.
-#[derive(Clone, Debug)]
-pub struct TakeWhile<W, P> {
-    maybe_walker: Option<W>,
-    predicate: P,
+impl<G, W, P> Walker<G> for SkipWhile<G, W, P>
+where
+    G: GraphRef,
+    W: Walker<G>,
+    P: FnMut(G, &W::Item) -> bool,
+{
+    type Item = W::Item;
+    #[inline]
+    fn walk_next(&mut self, graph: G) -> Option<Self::Item> {
+        match self.maybe_predicate.take() {
+            Some(mut predicate) => {
+                while let Some(item) = self.walker.walk_next(graph) {
+                    if !predicate(graph, &item) {
+                        return Some(item);
+                    }
+                }
+                None
+            }
+            None => self.walker.walk_next(graph),
+        }
+    }
 }
 
+/// A walker that yields elements so long as the predicate returns true.
+///
+/// After the predicate returns false for the first time, no further elements will be yielded.
+#[derive(Clone, Debug)]
+pub struct TakeWhile<G, W, P> {
+    maybe_walker: Option<W>,
+    predicate: P,
+    _graph: PhantomData<G>,
+}
 
-impl<G, Ix, W, P> Walker<G> for TakeWhile<W, P>
-    where Ix: IndexType,
-          W: Walker<G, Index=Ix>,
-          P: FnMut(&G, EdgeIndex<Ix>, NodeIndex<Ix>) -> bool,
+impl<G, W, P> TakeWhile<G, W, P> {
+    /// Create a new `TakeWhile` walker.
+    pub fn new(walker: W, predicate: P) -> Self
+    where
+        G: GraphRef,
+        W: Walker<G>,
+        P: FnMut(G, &W::Item) -> bool,
+    {
+        TakeWhile {
+            maybe_walker: Some(walker),
+            predicate,
+            _graph: PhantomData,
+        }
+    }
+}
+
+impl<G, W, P> Walker<G> for TakeWhile<G, W, P>
+where
+    G: GraphRef,
+    W: Walker<G>,
+    P: FnMut(G, &W::Item) -> bool,
 {
-    type Index = Ix;
+    type Item = W::Item;
     #[inline]
-    fn next(&mut self, graph: &G) -> Option<IndexPair<Ix>> {
-        let TakeWhile { ref mut maybe_walker, ref mut predicate } = *self;
-        let maybe_next_idx_pair = maybe_walker.as_mut().and_then(|walker| walker.next(graph));
-        if let Some((e, n)) = maybe_next_idx_pair {
-            if predicate(graph, e, n) {
-                return Some((e, n));
+    fn walk_next(&mut self, graph: G) -> Option<Self::Item> {
+        let TakeWhile {
+            ref mut maybe_walker,
+            ref mut predicate,
+            ..
+        } = *self;
+        let maybe_next_idx_pair = maybe_walker
+            .as_mut()
+            .and_then(|walker| walker.walk_next(graph));
+        if let Some(item) = maybe_next_idx_pair {
+            if predicate(graph, &item) {
+                return Some(item);
             } else {
                 *maybe_walker = None;
             }
@@ -537,88 +293,119 @@ impl<G, Ix, W, P> Walker<G> for TakeWhile<W, P>
     }
 }
 
-
 /// A walker that skips the first n steps of this walk, and then yields all further steps.
 #[derive(Clone, Debug)]
-pub struct Skip<G, Ix, W> {
+pub struct Skip<G, W> {
     walker: W,
     to_skip: usize,
     _graph: PhantomData<G>,
-    _index: PhantomData<Ix>,
 }
 
-
-impl<G, Ix, W> Walker<G> for Skip<G, Ix, W>
-    where Ix: IndexType,
-          W: Walker<G, Index=Ix>,
-{
-    type Index = Ix;
-    #[inline]
-    fn next(&mut self, graph: &G) -> Option<IndexPair<Ix>> {
-        if self.to_skip > 0 {
-            for _ in 0..self.to_skip {
-                self.walker.next(graph);
-            }
-            self.to_skip = 0;
+impl<G, W> Skip<G, W> {
+    /// Create a new `Skip` walker..
+    pub fn new(walker: W, to_skip: usize) -> Self {
+        Skip {
+            walker,
+            to_skip,
+            _graph: PhantomData,
         }
-        self.walker.next(graph)
     }
 }
 
+impl<G, W> Walker<G> for Skip<G, W>
+where
+    G: GraphRef,
+    W: Walker<G>,
+{
+    type Item = W::Item;
+    #[inline]
+    fn walk_next(&mut self, graph: G) -> Option<Self::Item> {
+        if self.to_skip > 0 {
+            for _ in 0..self.to_skip {
+                self.walker.walk_next(graph);
+            }
+            self.to_skip = 0;
+        }
+        self.walker.walk_next(graph)
+    }
+}
 
 /// A walker that yields the first n steps of this walk.
 #[derive(Clone, Debug)]
-pub struct Take<G, Ix, W> {
+pub struct Take<G, W> {
     walker: W,
     to_take: usize,
     _graph: PhantomData<G>,
-    _index: PhantomData<Ix>,
 }
 
+impl<G, W> Take<G, W> {
+    /// Create a new `Take` walker.
+    pub fn new(walker: W, to_take: usize) -> Self {
+        Take {
+            walker,
+            to_take,
+            _graph: PhantomData,
+        }
+    }
+}
 
-impl<G, Ix, W> Walker<G> for Take<G, Ix, W>
-    where Ix: IndexType,
-          W: Walker<G, Index=Ix>,
+impl<G, W> Walker<G> for Take<G, W>
+where
+    G: GraphRef,
+    W: Walker<G>,
 {
-    type Index = Ix;
+    type Item = W::Item;
     #[inline]
-    fn next(&mut self, graph: &G) -> Option<IndexPair<Ix>> {
+    fn walk_next(&mut self, graph: G) -> Option<Self::Item> {
         if self.to_take > 0 {
             self.to_take -= 1;
-            self.walker.next(graph)
+            self.walker.walk_next(graph)
         } else {
             None
         }
     }
 }
 
-
 /// A walker that repeats its internal walker endlessly.
 #[derive(Clone, Debug)]
-pub struct Cycle<G, Ix, W> {
+pub struct Cycle<G, W> {
     walker: W,
     clone: W,
     _graph: PhantomData<G>,
-    _index: PhantomData<Ix>,
 }
 
-
-impl<G, Ix, W> Walker<G> for Cycle<G, Ix, W>
-    where Ix: IndexType,
-          W: Walker<G, Index=Ix> + Clone,
+impl<G, W> Cycle<G, W>
+where
+    W: Clone,
 {
-    type Index = Ix;
+    /// Create a new `Cycle` walker.
+    pub fn new(walker: W) -> Self {
+        let clone = walker.clone();
+        Cycle {
+            walker,
+            clone,
+            _graph: PhantomData,
+        }
+    }
+}
+
+impl<G, W> Walker<G> for Cycle<G, W>
+where
+    G: GraphRef,
+    W: Walker<G> + Clone,
+{
+    type Item = W::Item;
     #[inline]
-    fn next(&mut self, graph: &G) -> Option<IndexPair<Ix>> {
-        self.clone.next(graph).or_else(|| {
+    fn walk_next(&mut self, graph: G) -> Option<Self::Item> {
+        self.clone.walk_next(graph).or_else(|| {
             self.clone = self.walker.clone();
-            self.clone.next(graph)
+            self.clone.walk_next(graph)
         })
     }
 }
 
-
 /// A walker that calls a function with a reference to each index pair before yielding them.
+///
 /// This is often useful for debugging a walker pipeline.
 #[derive(Clone, Debug)]
 pub struct Inspect<W, F> {
@@ -626,201 +413,25 @@ pub struct Inspect<W, F> {
     f: F,
 }
 
+impl<W, F> Inspect<W, F> {
+    /// Create a new `Inspect` walker.
+    pub fn new(walker: W, f: F) -> Self {
+        Inspect { walker, f }
+    }
+}
 
-impl<G, Ix, W, F> Walker<G> for Inspect<W, F>
-    where Ix: IndexType,
-          W: Walker<G, Index=Ix>,
-          F: FnMut(&G, EdgeIndex<Ix>, NodeIndex<Ix>),
+impl<G, W, F> Walker<G> for Inspect<W, F>
+where
+    G: GraphRef,
+    W: Walker<G>,
+    F: FnMut(G, &W::Item),
 {
-    type Index = Ix;
+    type Item = W::Item;
     #[inline]
-    fn next(&mut self, graph: &G) -> Option<IndexPair<Ix>> {
-        self.walker.next(graph).map(|(e, n)| {
-            (self.f)(graph, e, n);
-            (e, n)
+    fn walk_next(&mut self, graph: G) -> Option<W::Item> {
+        self.walker.walk_next(graph).map(|item| {
+            (self.f)(graph, &item);
+            item
         })
-    }
-}
-
-
-/// An iterator yielding index pairs produced by its internal walker and graph.
-#[derive(Clone, Debug)]
-pub struct Iter<'a, G: 'a, Ix, W> {
-    graph: &'a G,
-    walker: W,
-    _index: PhantomData<Ix>,
-}
-
-impl<'a, G, Ix, W> Iter<'a, G, Ix, W> {
-
-    /// Convert to an iterator that only yields the edge indices.
-    #[inline]
-    pub fn edges(self) -> IterEdges<'a, G, Ix, W> {
-        let Iter { graph, walker, .. } = self;
-        IterEdges {
-            graph: graph,
-            walker: walker,
-            _index: PhantomData,
-        }
-    }
-
-    /// Convert to an iterator that only yields the node indices.
-    #[inline]
-    pub fn nodes(self) -> IterNodes<'a, G, Ix, W> {
-        let Iter { graph, walker, .. } = self;
-        IterNodes {
-            graph: graph,
-            walker: walker,
-            _index: PhantomData,
-        }
-    }
-
-}
-
-impl<'a, G, Ix, W> Iterator for Iter<'a, G, Ix, W>
-    where Ix: IndexType,
-          W: Walker<G, Index=Ix>,
-{
-    type Item = IndexPair<Ix>;
-    #[inline]
-    fn next(&mut self) -> Option<IndexPair<Ix>> {
-        let Iter { ref mut walker, ref graph, .. } = *self;
-        walker.next(graph)
-    }
-}
-
-
-/// An iterator yielding edge indices produced by its internal walker and graph.
-#[derive(Clone, Debug)]
-pub struct IterEdges<'a, G: 'a, Ix, W> {
-    graph: &'a G,
-    walker: W,
-    _index: PhantomData<Ix>,
-}
-
-impl<'a, G, Ix, W> Iterator for IterEdges<'a, G, Ix, W>
-    where Ix: IndexType,
-          W: Walker<G, Index=Ix>,
-{
-    type Item = EdgeIndex<Ix>;
-    #[inline]
-    fn next(&mut self) -> Option<EdgeIndex<Ix>> {
-        let IterEdges { ref mut walker, ref graph, .. } = *self;
-        walker.next_edge(graph)
-    }
-}
-
-
-/// An iterator yielding node indices produced by its internal walker and graph.
-#[derive(Clone, Debug)]
-pub struct IterNodes<'a, G: 'a, Ix, W> {
-    graph: &'a G,
-    walker: W,
-    _index: PhantomData<Ix>,
-}
-
-impl<'a, G, Ix, W> Iterator for IterNodes<'a, G, Ix, W>
-    where Ix: IndexType,
-          W: Walker<G, Index=Ix>,
-{
-    type Item = NodeIndex<Ix>;
-    #[inline]
-    fn next(&mut self) -> Option<NodeIndex<Ix>> {
-        let IterNodes { ref mut walker, ref graph, .. } = *self;
-        walker.next_node(graph)
-    }
-}
-
-
-/// An iterator yielding weights associated with the index pairs produced by its internal walker
-/// and graph.
-#[derive(Clone, Debug)]
-pub struct IterWeights<'a, G: 'a, Ix, W> {
-    graph: &'a G,
-    walker: W,
-    _index: PhantomData<Ix>,
-}
-
-impl<'a, G, Ix, W> IterWeights<'a, G, Ix, W> {
-
-    /// Convert to an iterator yielding only the edge weights.
-    pub fn edges(self) -> IterEdgeWeights<'a, G, Ix, W> {
-        let IterWeights { graph, walker, .. } = self;
-        IterEdgeWeights {
-            graph: graph,
-            walker: walker,
-            _index: PhantomData,
-        }
-    }
-
-    /// Convert to an iterator yielding only the node weights.
-    pub fn nodes(self) -> IterNodeWeights<'a, G, Ix, W> {
-        let IterWeights { graph, walker, .. } = self;
-        IterNodeWeights {
-            graph: graph,
-            walker: walker,
-            _index: PhantomData,
-        }
-    }
-
-}
-
-impl<'a, G, Ix, W> Iterator for IterWeights<'a, G, Ix, W>
-    where Ix: IndexType,
-          W: Walker<G, Index=Ix>,
-          G: Index<EdgeIndex<Ix>>,
-          G: Index<NodeIndex<Ix>>,
-{
-    type Item = (&'a <G as Index<EdgeIndex<Ix>>>::Output, &'a <G as Index<NodeIndex<Ix>>>::Output);
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        let IterWeights { ref mut walker, ref graph, .. } = *self;
-        walker.next(graph).map(|(e, n)| (&graph[e], &graph[n]))
-    }
-}
-
-
-/// An iterator yielding edge weights associated with the indices produced by its internal walker
-/// and graph.
-#[derive(Clone, Debug)]
-pub struct IterEdgeWeights<'a, G: 'a, Ix, W> {
-    graph: &'a G,
-    walker: W,
-    _index: PhantomData<Ix>,
-}
-
-impl<'a, G, Ix, W> Iterator for IterEdgeWeights<'a, G, Ix, W>
-    where Ix: IndexType,
-          W: Walker<G, Index=Ix>,
-          G: Index<EdgeIndex<Ix>>,
-{
-    type Item = &'a <G as Index<EdgeIndex<Ix>>>::Output;
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        let IterEdgeWeights { ref mut walker, ref graph, .. } = *self;
-        walker.next_edge(graph).map(|e| &graph[e])
-    }
-}
-
-
-/// An iterator yielding node weights associated with the indices produced by its internal walker
-/// and graph.
-#[derive(Clone, Debug)]
-pub struct IterNodeWeights<'a, G: 'a, Ix, W> {
-    graph: &'a G,
-    walker: W,
-    _index: PhantomData<Ix>,
-}
-
-impl<'a, G, Ix, W> Iterator for IterNodeWeights<'a, G, Ix, W>
-    where Ix: IndexType,
-          W: Walker<G, Index=Ix>,
-          G: Index<NodeIndex<Ix>>,
-{
-    type Item = &'a <G as Index<NodeIndex<Ix>>>::Output;
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        let IterNodeWeights { ref mut walker, ref graph, .. } = *self;
-        walker.next_node(graph).map(|n| &graph[n])
     }
 }

--- a/tests/add_edges.rs
+++ b/tests/add_edges.rs
@@ -1,4 +1,3 @@
-
 extern crate daggy;
 
 use daggy::{Dag, WouldCycle};
@@ -9,38 +8,36 @@ struct Weight;
 
 #[test]
 fn add_edges_ok() {
-
     let mut dag = Dag::<Weight, u32, u32>::new();
     let root = dag.add_node(Weight);
     let a = dag.add_node(Weight);
     let b = dag.add_node(Weight);
     let c = dag.add_node(Weight);
 
-    let mut new_edges = dag.add_edges(once((root, a, 0))
+    let edges = once((root, a, 0))
         .chain(once((root, b, 1)))
-        .chain(once((root, c, 2))))
-        .unwrap();
+        .chain(once((root, c, 2)));
+    let mut new_edges = dag.add_edges(edges).unwrap();
 
     assert_eq!(new_edges.next(), dag.find_edge(root, a));
     assert_eq!(new_edges.next(), dag.find_edge(root, b));
     assert_eq!(new_edges.next(), dag.find_edge(root, c));
-
 }
-
 
 #[test]
 fn add_edges_err() {
-
     let mut dag = Dag::<Weight, u32, u32>::new();
     let root = dag.add_node(Weight);
     let a = dag.add_node(Weight);
     let b = dag.add_node(Weight);
     let c = dag.add_node(Weight);
 
-    let add_edges_result = dag.add_edges(once((root, a, 0))
-        .chain(once((root, b, 1)))
-        .chain(once((root, c, 2)))
-        .chain(once((c, root, 3))));
+    let add_edges_result = dag.add_edges(
+        once((root, a, 0))
+            .chain(once((root, b, 1)))
+            .chain(once((root, c, 2)))
+            .chain(once((c, root, 3))),
+    );
 
     match add_edges_result {
         Err(WouldCycle(returned_weights)) => assert_eq!(returned_weights, vec![3, 2, 1, 0]),
@@ -65,15 +62,42 @@ fn add_edges_more() {
 #[test]
 fn add_edges_more2() {
     let max_node = 10;
-    let edges = &[(1, 4), (3, 4), (2, 5), (3, 5), (2, 8), (1, 9), (1, 8),
-                  (1, 3), (2, 7), (1, 7), (0, 6), (1, 2), (0, 7), (1, 6),
-                  (2, 4), (0, 1), (0, 9), (2, 9), (2, 6), (0, 4), (2, 3),
-                  (0, 2), (0, 3), (0, 5), (0, 8), (1, 5)];
+    let edges = &[
+        (1, 4),
+        (3, 4),
+        (2, 5),
+        (3, 5),
+        (2, 8),
+        (1, 9),
+        (1, 8),
+        (1, 3),
+        (2, 7),
+        (1, 7),
+        (0, 6),
+        (1, 2),
+        (0, 7),
+        (1, 6),
+        (2, 4),
+        (0, 1),
+        (0, 9),
+        (2, 9),
+        (2, 6),
+        (0, 4),
+        (2, 3),
+        (0, 2),
+        (0, 3),
+        (0, 5),
+        (0, 8),
+        (1, 5),
+    ];
     let mut dag = Dag::<Weight, u32, u32>::with_capacity(max_node, edges.len());
     for _ in 0..max_node {
         dag.add_node(Weight);
     }
     for &(a, b) in edges {
-        assert!(dag.add_edge(NodeIndex::new(a), NodeIndex::new(b), 0).is_ok());
+        assert!(
+            dag.add_edge(NodeIndex::new(a), NodeIndex::new(b), 0)
+                .is_ok()
+        );
     }
 }

--- a/tests/iterators.rs
+++ b/tests/iterators.rs
@@ -1,14 +1,11 @@
-
 extern crate daggy;
 
 use daggy::{Dag, Walker};
 
 struct Weight;
 
-
 #[test]
 fn children() {
-
     let mut dag = Dag::<Weight, Weight, u32>::new();
     let parent = dag.add_node(Weight);
     let (_, a) = dag.add_child(parent, Weight, Weight);
@@ -16,7 +13,7 @@ fn children() {
     let (_, c) = dag.add_child(parent, Weight, Weight);
 
     {
-        let mut children = dag.children(parent).iter(&dag).nodes();
+        let mut children = dag.children(parent).iter(&dag).map(|(_, n)| n);
         assert_eq!(Some(c), children.next());
         assert_eq!(Some(b), children.next());
         assert_eq!(Some(a), children.next());
@@ -27,7 +24,7 @@ fn children() {
     let (e, _) = dag.add_child(b, Weight, Weight);
     let (f, _) = dag.add_child(b, Weight, Weight);
     {
-        let mut children = dag.children(b).iter(&dag).edges();
+        let mut children = dag.children(b).iter(&dag).map(|(e, _)| e);
         assert_eq!(Some(f), children.next());
         assert_eq!(Some(e), children.next());
         assert_eq!(Some(d), children.next());
@@ -37,7 +34,6 @@ fn children() {
 
 #[test]
 fn parents() {
-
     let mut dag = Dag::<Weight, Weight, u32>::new();
     let child = dag.add_node(Weight);
     let (a_e, a_n) = dag.add_parent(child, Weight, Weight);
@@ -53,12 +49,10 @@ fn parents() {
         assert_eq!(Some((a_e, a_n)), parents.next());
         assert_eq!(None, parents.next());
     }
-
 }
 
 #[test]
 fn weights() {
-
     let mut dag = Dag::<&str, i32, u32>::new();
     let parent = dag.add_node("0");
     dag.add_child(parent, 1, "1");
@@ -66,7 +60,9 @@ fn weights() {
     dag.add_child(parent, 3, "3");
 
     {
-        let mut children = dag.children(parent).iter_weights(&dag);
+        let mut children = dag.children(parent)
+            .iter(&dag)
+            .map(|(e, n)| (&dag[e], &dag[n]));
         assert_eq!(Some((&3, &"3")), children.next());
         assert_eq!(Some((&2, &"2")), children.next());
         assert_eq!(Some((&1, &"1")), children.next());
@@ -74,7 +70,7 @@ fn weights() {
     }
 
     {
-        let mut child_edges = dag.children(parent).iter_weights(&dag).edges();
+        let mut child_edges = dag.children(parent).iter(&dag).map(|(e, _)| &dag[e]);
         assert_eq!(Some(&3), child_edges.next());
         assert_eq!(Some(&2), child_edges.next());
         assert_eq!(Some(&1), child_edges.next());
@@ -82,13 +78,10 @@ fn weights() {
     }
 
     {
-        let mut child_nodes = dag.children(parent).iter_weights(&dag).nodes();
+        let mut child_nodes = dag.children(parent).iter(&dag).map(|(_, n)| &dag[n]);
         assert_eq!(Some(&"3"), child_nodes.next());
         assert_eq!(Some(&"2"), child_nodes.next());
         assert_eq!(Some(&"1"), child_nodes.next());
         assert_eq!(None, child_nodes.next());
     }
-
 }
-
-


### PR DESCRIPTION
The biggest change here is the removal of the custom `daggy::Walker`
trait in favour of using the `petgraph::visit::Walker` trait. All the
same adaptors remain, however they require a little more boilerplate in
their construction as they have no associated adaptor methods on the
`Walker` trait itself. Perhaps one day there might be interest in
adding these upstream.

Add new petgraph constructors including `from_elements`, `from_edges`
and `extend_with_edges`. All applicable petgraph graph traits have also
been added. We don't implement the `Build` or `Create` traits as adding
an edge to a `Dag` may fail if adding the edge would cause a cycle.

Also adds serde (de)serialization support via a new `serde-1` feature.

Tests have been updated in accordance with these changes.

@bluss just thought I'd ping you in case you were interested in this
update!