### PR TITLE
Implementation of the StableDag data structure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/mitchmindtree/daggy.git"
 homepage = "https://github.com/mitchmindtree/daggy"
 
 [dependencies]
-petgraph = { version = "0.4", default-features = false }
+petgraph = { version = "0.4", default-features = false, features = ["stable_graph"] }
 serde = { version = "1.0", optional = true }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,12 @@ repository = "https://github.com/mitchmindtree/daggy.git"
 homepage = "https://github.com/mitchmindtree/daggy"
 
 [dependencies]
-petgraph = { version = "0.4", default-features = false, features = ["stable_graph"] }
+petgraph = { version = "0.4", default-features = false }
 serde = { version = "1.0", optional = true }
 
 [features]
 serde-1 = ["petgraph/serde-1", "serde"]
+stable_dag = ["petgraph/stable_graph"]
 
 [package.metadata.docs.rs]
 features = ["serde-1"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ use std::ops::{Index, IndexMut};
 pub use petgraph::graph::{EdgeIndex, EdgeWeightsMut, NodeIndex, NodeWeightsMut};
 pub use petgraph::visit::Walker;
 
+#[cfg(feature = "stable_dag")]
 pub mod stabledag;
 
 pub mod walker;

--- a/src/stabledag.rs
+++ b/src/stabledag.rs
@@ -516,6 +516,10 @@ where
         self.graph.remove_node(node)
     }
 
+    pub fn contains_node(&self, a: NodeIndex<Ix>) -> bool {
+        self.graph.contains_node(a)
+    }
+
     /// Remove an edge and return its weight, or `None` if it didn't exist.
     ///
     /// Computes in **O(e')** time, where **e'** is the size of four particular edge lists, for the

--- a/src/stabledag.rs
+++ b/src/stabledag.rs
@@ -1,6 +1,6 @@
-//! This module includes the implementation of the **StableDag** data structre. The **StableDag** has
-//! similar functionality as the **Dag** data structure, but it does not invalidate node indices when
-//! a node is removed.
+//! This module includes the implementation of the **StableDag** data structure. The **StableDag**
+//! has a similar functionality to the **Dag** data structure, but it does not invalidate node
+//! indices when a node is removed.
 
 use petgraph as pg;
 use petgraph::algo::{has_path_connecting, DfsSpace};
@@ -19,6 +19,7 @@ use std::ops::{Index, IndexMut};
 pub use petgraph::graph::{EdgeIndex, EdgeWeightsMut, NodeIndex, NodeWeightsMut};
 pub use petgraph::visit::Walker;
 
+use WouldCycle;
 use walker;
 
 
@@ -27,13 +28,14 @@ pub type Edges<'a, E, Ix> = pg::stable_graph::Edges<'a, E, pg::Directed, Ix>;
 
 /// A Directed acyclic graph (DAG) data structure.
 ///
-/// StableDag is a thin wrapper around petgraph's `StableGraph` data structure, providing a refined API for
-/// dealing specifically with DAGs.
+/// StableDag is a thin wrapper around petgraph's `StableGraph` data structure, providing a refined
+/// API for dealing specifically with DAGs.
 ///
 /// Note: The following documentation is adapted from petgraph's [**StableGraph** documentation]
 /// (http://bluss.github.io/petulant-avenger-graphlibrary/doc/petgraph/graph/struct.StableGraph.html).
 ///
-/// **StableDag** is parameterized over the node weight **N**, edge weight **E** and index type **Ix**.
+/// **StableDag** is parameterized over the node weight **N**, edge weight **E** and index type
+/// **Ix**.
 ///
 /// **NodeIndex** is a type that acts as a reference to nodes, but these are only stable across
 /// certain operations. **StableDag++ keeps all indices stable even when removing nodes/edges.
@@ -41,8 +43,8 @@ pub type Edges<'a, E, Ix> = pg::stable_graph::Edges<'a, E, pg::Directed, Ix>;
 /// The **Ix** parameter is u32 by default. The goal is that you can ignore this parameter
 /// completely unless you need a very large **StableDag** -- then you can use usize.
 ///
-/// The **StableDag** also offers methods for accessing the underlying **StableGraph**, which can be useful
-/// for taking advantage of petgraph's various graph-related algorithms.
+/// The **StableDag** also offers methods for accessing the underlying **StableGraph**, which can be
+/// useful for taking advantage of petgraph's various graph-related algorithms.
 #[derive(Clone, Debug)]
 pub struct StableDag<N, E, Ix: IndexType = DefaultIx> {
     graph: StableDiGraph<N, E, Ix>,
@@ -72,14 +74,9 @@ pub struct EdgeIndices<Ix: IndexType> {
 /// An alias to simplify the **Recursive** **Walker** type returned by **StableDag**.
 pub type RecursiveWalk<N, E, Ix, F> = walker::Recursive<StableDag<N, E, Ix>, F>;
 
-/// An error returned by the `StableDag::add_edge` method in the case that adding an edge would have
-/// caused the graph to cycle.
-#[derive(Copy, Clone)]
-pub struct WouldCycle<E>(pub E);
-
 impl<N, E, Ix> StableDag<N, E, Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     /// Create a new, empty `StableDag`.
     pub fn new() -> Self {
@@ -105,11 +102,11 @@ impl<N, E, Ix> StableDag<N, E, Ix>
     ///
     /// Returns an `Err` if adding any of the edges would cause a cycle.
     pub fn from_edges<I>(edges: I) -> Result<Self, WouldCycle<E>>
-        where
-            I: IntoIterator,
-            I::Item: IntoWeightedEdge<E>,
-            <I::Item as IntoWeightedEdge<E>>::NodeId: Into<NodeIndex<Ix>>,
-            N: Default,
+    where
+        I: IntoIterator,
+        I::Item: IntoWeightedEdge<E>,
+        <I::Item as IntoWeightedEdge<E>>::NodeId: Into<NodeIndex<Ix>>,
+        N: Default,
     {
         let mut dag = Self::default();
         dag.extend_with_edges(edges)?;
@@ -127,11 +124,11 @@ impl<N, E, Ix> StableDag<N, E, Ix>
     ///
     /// Returns an `Err` if adding an edge would cause a cycle.
     pub fn extend_with_edges<I>(&mut self, edges: I) -> Result<(), WouldCycle<E>>
-        where
-            I: IntoIterator,
-            I::Item: IntoWeightedEdge<E>,
-            <I::Item as IntoWeightedEdge<E>>::NodeId: Into<NodeIndex<Ix>>,
-            N: Default,
+    where
+        I: IntoIterator,
+        I::Item: IntoWeightedEdge<E>,
+        <I::Item as IntoWeightedEdge<E>>::NodeId: Into<NodeIndex<Ix>>,
+        N: Default,
     {
         for edge in edges {
             let (source, target, weight) = edge.into_weighted_edge();
@@ -149,9 +146,9 @@ impl<N, E, Ix> StableDag<N, E, Ix>
     ///
     /// Returns an `Err` if an edge would cause a cycle within the graph.
     pub fn from_elements<I>(elements: I) -> Result<Self, WouldCycle<E>>
-        where
-            Self: Sized,
-            I: IntoIterator<Item = pg::data::Element<N, E>>,
+    where
+        Self: Sized,
+        I: IntoIterator<Item = pg::data::Element<N, E>>,
     {
         let mut dag = Self::default();
         for elem in elements {
@@ -177,9 +174,9 @@ impl<N, E, Ix> StableDag<N, E, Ix>
     ///
     /// The resulting graph has the same structure and the same graph indices as `self`.
     pub fn map<'a, F, G, N2, E2>(&'a self, node_map: F, edge_map: G) -> StableDag<N2, E2, Ix>
-        where
-            F: FnMut(NodeIndex<Ix>, &'a N) -> N2,
-            G: FnMut(EdgeIndex<Ix>, &'a E) -> E2,
+    where
+        F: FnMut(NodeIndex<Ix>, &'a N) -> N2,
+        G: FnMut(EdgeIndex<Ix>, &'a E) -> E2,
     {
         let graph = self.graph.map(node_map, edge_map);
         let cycle_state = self.cycle_state.clone();
@@ -189,8 +186,8 @@ impl<N, E, Ix> StableDag<N, E, Ix>
         }
     }
 
-    /// Create a new `StableDag` by mapping node and edge weights. A node or edge may be mapped to `None`
-    /// to exclude it from the resulting `StableDag`.
+    /// Create a new `StableDag` by mapping node and edge weights. A node or edge may be mapped to
+    /// `None` to exclude it from the resulting `StableDag`.
     ///
     /// Nodes are mapped first with the `node_map` closure, then `edge_map` is called for the edges
     /// that have not had any endpoint removed.
@@ -198,9 +195,9 @@ impl<N, E, Ix> StableDag<N, E, Ix>
     /// The resulting graph has the structure of a subgraph of the original graph. Nodes and edges
     /// that are not removed maintain their old node or edge indices.
     pub fn filter_map<'a, F, G, N2, E2>(&'a self, node_map: F, edge_map: G) -> StableDag<N2, E2, Ix>
-        where
-            F: FnMut(NodeIndex<Ix>, &'a N) -> Option<N2>,
-            G: FnMut(EdgeIndex<Ix>, &'a E) -> Option<E2>,
+    where
+        F: FnMut(NodeIndex<Ix>, &'a N) -> Option<N2>,
+        G: FnMut(EdgeIndex<Ix>, &'a E) -> Option<E2>,
     {
         let graph = self.graph.filter_map(node_map, edge_map);
         let cycle_state = DfsSpace::new(&graph);
@@ -250,7 +247,8 @@ impl<N, E, Ix> StableDag<N, E, Ix>
     ///
     /// **Note:** If you're adding a new node and immediately adding a single edge to that node from
     /// some other node, consider using the [add_child](./struct.StableDag.html#method.add_child) or
-    /// [add_parent](./struct.StableDag.html#method.add_parent) methods instead for better performance.
+    /// [add_parent](./struct.StableDag.html#method.add_parent) methods instead for better
+    /// performance.
     ///
     /// **Panics** if the Graph is at the maximum number of nodes for its index type.
     pub fn add_node(&mut self, weight: N) -> NodeIndex<Ix> {
@@ -273,12 +271,13 @@ impl<N, E, Ix> StableDag<N, E, Ix>
     /// (http://bluss.github.io/petulant-avenger-graphlibrary/doc/petgraph/algo/fn.is_cyclic_directed.html)
     /// function is used to check whether or not adding the edge would create a cycle.
     ///
-    /// **Note:** StableDag allows adding parallel ("duplicate") edges. If you want to avoid this, use
-    /// [`update_edge`](./struct.StableDag.html#method.update_edge) instead.
+    /// **Note:** StableDag allows adding parallel ("duplicate") edges. If you want to avoid this,
+    /// use [`update_edge`](./struct.StableDag.html#method.update_edge) instead.
     ///
     /// **Note:** If you're adding a new node and immediately adding a single edge to that node from
     /// some other node, consider using the [add_child](./struct.StableDag.html#method.add_child) or
-    /// [add_parent](./struct.StableDag.html#method.add_parent) methods instead for better performance.
+    /// [add_parent](./struct.StableDag.html#method.add_parent) methods instead for better
+    /// performance.
     ///
     /// **Panics** if either `a` or `b` do not exist within the **StableDag**.
     ///
@@ -321,8 +320,8 @@ impl<N, E, Ix> StableDag<N, E, Ix>
     /// instead a `WouldCycle<Vec<E>>` error with the unused weights will be returned. The order of
     /// the returned `Vec` will be the reverse of the given order.
     ///
-    /// **Note:** StableDag allows adding parallel ("duplicate") edges. If you want to avoid this, use
-    /// [`update_edges`](./struct.StableDag.html#method.update_edges) instead.
+    /// **Note:** StableDag allows adding parallel ("duplicate") edges. If you want to avoid this,
+    /// use [`update_edges`](./struct.StableDag.html#method.update_edges) instead.
     ///
     /// **Note:** If you're adding a series of new nodes and edges to a single node, consider using
     ///  the [add_child](./struct.StableDag.html#method.add_child) or [add_parent]
@@ -330,8 +329,8 @@ impl<N, E, Ix> StableDag<N, E, Ix>
     ///
     /// **Panics** if the Graph is at the maximum number of nodes for its index type.
     pub fn add_edges<I>(&mut self, edges: I) -> Result<EdgeIndices<Ix>, WouldCycle<Vec<E>>>
-        where
-            I: IntoIterator<Item = (NodeIndex<Ix>, NodeIndex<Ix>, E)>,
+    where
+        I: IntoIterator<Item = (NodeIndex<Ix>, NodeIndex<Ix>, E)>,
     {
         let mut num_edges = 0;
         let mut should_check_for_cycle = false;
@@ -370,7 +369,8 @@ impl<N, E, Ix> StableDag<N, E, Ix>
     ///
     /// If the edge doesn't already exist, it will be added using the `add_edge` method.
     ///
-    /// Please read the [`add_edge`](./struct.StableDag.html#method.add_edge) for more important details.
+    /// Please read the [`add_edge`](./struct.StableDag.html#method.add_edge) for more important
+    /// details.
     ///
     /// Checks if the edge would create a cycle in the Graph.
     ///
@@ -479,18 +479,6 @@ impl<N, E, Ix> StableDag<N, E, Ix>
         self.graph.node_weight_mut(node)
     }
 
-    /// Read from the internal node array.
-//    pub fn raw_nodes(&self) -> RawNodes<N, Ix> {
-//        self.graph.raw_nodes()
-//    }
-
-    /// An iterator yielding mutable access to all node weights.
-    ///
-    /// The order in which weights are yielded matches the order of their node indices.
-//    pub fn node_weights_mut(&mut self) -> NodeWeightsMut<N, Ix> {
-//        self.graph.node_weights_mut()
-//    }
-
     /// Borrow the weight from the edge at the given index.
     pub fn edge_weight(&self, edge: EdgeIndex<Ix>) -> Option<&E> {
         self.graph.edge_weight(edge)
@@ -500,18 +488,6 @@ impl<N, E, Ix> StableDag<N, E, Ix>
     pub fn edge_weight_mut(&mut self, edge: EdgeIndex<Ix>) -> Option<&mut E> {
         self.graph.edge_weight_mut(edge)
     }
-
-    /// Read from the internal edge array.
-//    pub fn raw_edges(&self) -> RawEdges<E, Ix> {
-//        self.graph.raw_edges()
-//    }
-
-    /// An iterator yielding mutable access to all edge weights.
-    ///
-    /// The order in which weights are yielded matches the order of their edge indices.
-//    pub fn edge_weights_mut(&mut self) -> EdgeWeightsMut<E, Ix> {
-//        self.graph.edge_weights_mut()
-//    }
 
     /// Index the `StableDag` by two indices.
     ///
@@ -526,10 +502,10 @@ impl<N, E, Ix> StableDag<N, E, Ix>
         &mut <StableDiGraph<N, E, Ix> as Index<A>>::Output,
         &mut <StableDiGraph<N, E, Ix> as Index<B>>::Output,
     )
-        where
-            StableDiGraph<N, E, Ix>: IndexMut<A> + IndexMut<B>,
-            A: GraphIndex,
-            B: GraphIndex,
+    where
+        StableDiGraph<N, E, Ix>: IndexMut<A> + IndexMut<B>,
+        A: GraphIndex,
+        B: GraphIndex,
     {
         self.graph.index_twice_mut(a, b)
     }
@@ -591,8 +567,8 @@ impl<N, E, Ix> StableDag<N, E, Ix>
         start: NodeIndex<Ix>,
         recursive_fn: F,
     ) -> RecursiveWalk<N, E, Ix, F>
-        where
-            F: FnMut(&Self, NodeIndex<Ix>) -> Option<(EdgeIndex<Ix>, NodeIndex<Ix>)>,
+    where
+        F: FnMut(&Self, NodeIndex<Ix>) -> Option<(EdgeIndex<Ix>, NodeIndex<Ix>)>,
     {
         walker::Recursive::new(start, recursive_fn)
     }
@@ -604,8 +580,8 @@ impl<N, E, Ix> StableDag<N, E, Ix>
 /// If our parent *a* has no parents or our child *b* has no children, or if there was already an
 /// edge connecting *a* to *b*, we know that adding this edge has not caused the graph to cycle.
 fn must_check_for_cycle<N, E, Ix>(dag: &StableDag<N, E, Ix>, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> bool
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     dag.parents(a).walk_next(dag).is_some() && dag.children(b).walk_next(dag).is_some()
         && dag.find_edge(a, b).is_none()
@@ -614,8 +590,8 @@ fn must_check_for_cycle<N, E, Ix>(dag: &StableDag<N, E, Ix>, a: NodeIndex<Ix>, b
 // Dag implementations.
 
 impl<N, E, Ix> Into<StableDiGraph<N, E, Ix>> for StableDag<N, E, Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     fn into(self) -> StableDiGraph<N, E, Ix> {
         self.into_graph()
@@ -623,8 +599,8 @@ impl<N, E, Ix> Into<StableDiGraph<N, E, Ix>> for StableDag<N, E, Ix>
 }
 
 impl<N, E, Ix> Default for StableDag<N, E, Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     fn default() -> Self {
         StableDag::new()
@@ -633,14 +609,14 @@ impl<N, E, Ix> Default for StableDag<N, E, Ix>
 
 #[cfg(feature = "serde-1")]
 impl<N, E, Ix> Serialize for StableDag<N, E, Ix>
-    where
-        N: Serialize,
-        E: Serialize,
-        Ix: IndexType + Serialize,
+where
+    N: Serialize,
+    E: Serialize,
+    Ix: IndexType + Serialize,
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
+    where
+        S: Serializer,
     {
         self.graph.serialize(serializer)
     }
@@ -648,15 +624,15 @@ impl<N, E, Ix> Serialize for StableDag<N, E, Ix>
 
 #[cfg(feature = "serde-1")]
 impl<'de, N, E, Ix> Deserialize<'de> for StableDag<N, E, Ix>
-    where
-        Self: Sized,
-        N: Deserialize<'de>,
-        E: Deserialize<'de>,
-        Ix: IndexType + Deserialize<'de>,
+where
+    Self: Sized,
+    N: Deserialize<'de>,
+    E: Deserialize<'de>,
+    Ix: IndexType + Deserialize<'de>,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: Deserializer<'de>,
+    where
+        D: Deserializer<'de>,
     {
         let graph = Deserialize::deserialize(deserializer)?;
         let cycle_state = DfsSpace::new(&graph);
@@ -669,16 +645,16 @@ impl<'de, N, E, Ix> Deserialize<'de> for StableDag<N, E, Ix>
 }
 
 impl<N, E, Ix> GraphBase for StableDag<N, E, Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     type NodeId = NodeIndex<Ix>;
     type EdgeId = EdgeIndex<Ix>;
 }
 
 impl<N, E, Ix> NodeCount for StableDag<N, E, Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     fn node_count(&self) -> usize {
         StableDag::node_count(self)
@@ -686,8 +662,8 @@ impl<N, E, Ix> NodeCount for StableDag<N, E, Ix>
 }
 
 impl<N, E, Ix> GraphProp for StableDag<N, E, Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     type EdgeType = pg::Directed;
     fn is_directed(&self) -> bool {
@@ -696,8 +672,8 @@ impl<N, E, Ix> GraphProp for StableDag<N, E, Ix>
 }
 
 impl<N, E, Ix> pg::visit::Visitable for StableDag<N, E, Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     type Map = <StableDiGraph<N, E, Ix> as Visitable>::Map;
     fn visit_map(&self) -> Self::Map {
@@ -709,16 +685,16 @@ impl<N, E, Ix> pg::visit::Visitable for StableDag<N, E, Ix>
 }
 
 impl<N, E, Ix> pg::visit::Data for StableDag<N, E, Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     type NodeWeight = N;
     type EdgeWeight = E;
 }
 
 impl<N, E, Ix> pg::data::DataMap for StableDag<N, E, Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     fn node_weight(&self, id: Self::NodeId) -> Option<&Self::NodeWeight> {
         self.graph.node_weight(id)
@@ -729,8 +705,8 @@ impl<N, E, Ix> pg::data::DataMap for StableDag<N, E, Ix>
 }
 
 impl<N, E, Ix> pg::data::DataMapMut for StableDag<N, E, Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     fn node_weight_mut(&mut self, id: Self::NodeId) -> Option<&mut Self::NodeWeight> {
         self.graph.node_weight_mut(id)
@@ -741,8 +717,8 @@ impl<N, E, Ix> pg::data::DataMapMut for StableDag<N, E, Ix>
 }
 
 impl<'a, N, E, Ix> IntoNeighbors for &'a StableDag<N, E, Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     type Neighbors = pg::stable_graph::Neighbors<'a, E, Ix>;
     fn neighbors(self, n: NodeIndex<Ix>) -> Self::Neighbors {
@@ -751,8 +727,8 @@ impl<'a, N, E, Ix> IntoNeighbors for &'a StableDag<N, E, Ix>
 }
 
 impl<'a, N, E, Ix> IntoNeighborsDirected for &'a StableDag<N, E, Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     type NeighborsDirected = pg::stable_graph::Neighbors<'a, E, Ix>;
     fn neighbors_directed(self, n: NodeIndex<Ix>, d: pg::Direction) -> Self::Neighbors {
@@ -761,8 +737,8 @@ impl<'a, N, E, Ix> IntoNeighborsDirected for &'a StableDag<N, E, Ix>
 }
 
 impl<'a, N, E, Ix> IntoEdgeReferences for &'a StableDag<N, E, Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     type EdgeRef = pg::stable_graph::EdgeReference<'a, E, Ix>;
     type EdgeReferences = pg::stable_graph::EdgeReferences<'a, E, Ix>;
@@ -772,8 +748,8 @@ impl<'a, N, E, Ix> IntoEdgeReferences for &'a StableDag<N, E, Ix>
 }
 
 impl<'a, N, E, Ix> IntoEdges for &'a StableDag<N, E, Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     type Edges = Edges<'a, E, Ix>;
     fn edges(self, a: Self::NodeId) -> Self::Edges {
@@ -782,8 +758,8 @@ impl<'a, N, E, Ix> IntoEdges for &'a StableDag<N, E, Ix>
 }
 
 impl<'a, N, E, Ix> IntoEdgesDirected for &'a StableDag<N, E, Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     type EdgesDirected = Edges<'a, E, Ix>;
     fn edges_directed(self, a: Self::NodeId, dir: pg::Direction) -> Self::EdgesDirected {
@@ -792,9 +768,8 @@ impl<'a, N, E, Ix> IntoEdgesDirected for &'a StableDag<N, E, Ix>
 }
 
 impl<'a, N, E, Ix> IntoNodeIdentifiers for &'a StableDag<N, E, Ix>
-    where
-        Ix: IndexType
-
+where
+    Ix: IndexType,
 {
     type NodeIdentifiers = pg::stable_graph::NodeIndices<'a, N, Ix>;
     fn node_identifiers(self) -> Self::NodeIdentifiers {
@@ -803,8 +778,8 @@ impl<'a, N, E, Ix> IntoNodeIdentifiers for &'a StableDag<N, E, Ix>
 }
 
 impl<'a, N, E, Ix> IntoNodeReferences for &'a StableDag<N, E, Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     type NodeRef = (NodeIndex<Ix>, &'a N);
     type NodeReferences = pg::stable_graph::NodeReferences<'a, N, Ix>;
@@ -814,8 +789,8 @@ impl<'a, N, E, Ix> IntoNodeReferences for &'a StableDag<N, E, Ix>
 }
 
 impl<N, E, Ix> NodeIndexable for StableDag<N, E, Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     fn node_bound(&self) -> usize {
         self.graph.node_bound()
@@ -829,14 +804,14 @@ impl<N, E, Ix> NodeIndexable for StableDag<N, E, Ix>
 }
 
 impl<N, E, Ix> NodeCompactIndexable for StableDag<N, E, Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
 }
 
 impl<N, E, Ix> Index<NodeIndex<Ix>> for StableDag<N, E, Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     type Output = N;
     fn index(&self, index: NodeIndex<Ix>) -> &N {
@@ -845,8 +820,8 @@ impl<N, E, Ix> Index<NodeIndex<Ix>> for StableDag<N, E, Ix>
 }
 
 impl<N, E, Ix> IndexMut<NodeIndex<Ix>> for StableDag<N, E, Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     fn index_mut(&mut self, index: NodeIndex<Ix>) -> &mut N {
         &mut self.graph[index]
@@ -854,8 +829,8 @@ impl<N, E, Ix> IndexMut<NodeIndex<Ix>> for StableDag<N, E, Ix>
 }
 
 impl<N, E, Ix> Index<EdgeIndex<Ix>> for StableDag<N, E, Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     type Output = E;
     fn index(&self, index: EdgeIndex<Ix>) -> &E {
@@ -864,8 +839,8 @@ impl<N, E, Ix> Index<EdgeIndex<Ix>> for StableDag<N, E, Ix>
 }
 
 impl<N, E, Ix> IndexMut<EdgeIndex<Ix>> for StableDag<N, E, Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     fn index_mut(&mut self, index: EdgeIndex<Ix>) -> &mut E {
         &mut self.graph[index]
@@ -873,8 +848,8 @@ impl<N, E, Ix> IndexMut<EdgeIndex<Ix>> for StableDag<N, E, Ix>
 }
 
 impl<N, E, Ix> GetAdjacencyMatrix for StableDag<N, E, Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     type AdjMatrix = <StableDiGraph<N, E, Ix> as GetAdjacencyMatrix>::AdjMatrix;
     fn adjacency_matrix(&self) -> Self::AdjMatrix {
@@ -886,8 +861,8 @@ impl<N, E, Ix> GetAdjacencyMatrix for StableDag<N, E, Ix>
 }
 
 impl<'a, N, E, Ix> Walker<&'a StableDag<N, E, Ix>> for Children<N, E, Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     type Item = (EdgeIndex<Ix>, NodeIndex<Ix>);
     #[inline]
@@ -897,8 +872,8 @@ impl<'a, N, E, Ix> Walker<&'a StableDag<N, E, Ix>> for Children<N, E, Ix>
 }
 
 impl<'a, N, E, Ix> Walker<&'a StableDag<N, E, Ix>> for Parents<N, E, Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     type Item = (EdgeIndex<Ix>, NodeIndex<Ix>);
     #[inline]
@@ -908,29 +883,11 @@ impl<'a, N, E, Ix> Walker<&'a StableDag<N, E, Ix>> for Parents<N, E, Ix>
 }
 
 impl<Ix> Iterator for EdgeIndices<Ix>
-    where
-        Ix: IndexType,
+where
+    Ix: IndexType,
 {
     type Item = EdgeIndex<Ix>;
     fn next(&mut self) -> Option<EdgeIndex<Ix>> {
         self.indices.next().map(|i| EdgeIndex::new(i))
-    }
-}
-
-impl<E> ::std::fmt::Debug for WouldCycle<E> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        writeln!(f, "WouldCycle")
-    }
-}
-
-impl<E> ::std::fmt::Display for WouldCycle<E> {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
-        writeln!(f, "{:?}", self)
-    }
-}
-
-impl<E> ::std::error::Error for WouldCycle<E> {
-    fn description(&self) -> &str {
-        "Adding this edge would have created a cycle"
     }
 }

--- a/src/stabledag.rs
+++ b/src/stabledag.rs
@@ -21,6 +21,7 @@ pub use petgraph::visit::Walker;
 
 use WouldCycle;
 use walker;
+use Dag;
 
 
 /// An iterator yielding all edges to/from some node.
@@ -889,5 +890,20 @@ where
     type Item = EdgeIndex<Ix>;
     fn next(&mut self) -> Option<EdgeIndex<Ix>> {
         self.indices.next().map(|i| EdgeIndex::new(i))
+    }
+}
+
+/// Convert a `Dag` into a `StableDag`
+///
+/// The resulting graph has the same node and edge indices as
+/// the original graph.
+impl<N, E, Ix> From<Dag<N, E, Ix>> for StableDag<N, E, Ix>
+    where Ix: IndexType,
+{
+    fn from(g: Dag<N, E, Ix>) -> Self {
+        StableDag {
+            graph: StableDiGraph::from(g.graph),
+            cycle_state: DfsSpace::default(),
+        }
     }
 }

--- a/tests/add_edges_stable.rs
+++ b/tests/add_edges_stable.rs
@@ -1,7 +1,7 @@
 extern crate daggy;
 
-use daggy::stabledag::{StableDag, WouldCycle};
-use daggy::stabledag::NodeIndex;
+use daggy::WouldCycle;
+use daggy::stabledag::{StableDag, NodeIndex};
 use std::iter::once;
 
 struct Weight;

--- a/tests/add_edges_stable.rs
+++ b/tests/add_edges_stable.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "stable_dag")]
 extern crate daggy;
 
 use daggy::WouldCycle;

--- a/tests/add_edges_stable.rs
+++ b/tests/add_edges_stable.rs
@@ -1,0 +1,103 @@
+extern crate daggy;
+
+use daggy::stabledag::{StableDag, WouldCycle};
+use daggy::stabledag::NodeIndex;
+use std::iter::once;
+
+struct Weight;
+
+#[test]
+fn add_edges_ok_stable() {
+    let mut dag = StableDag::<Weight, u32, u32>::new();
+    let root = dag.add_node(Weight);
+    let a = dag.add_node(Weight);
+    let b = dag.add_node(Weight);
+    let c = dag.add_node(Weight);
+
+    let edges = once((root, a, 0))
+        .chain(once((root, b, 1)))
+        .chain(once((root, c, 2)));
+    let mut new_edges = dag.add_edges(edges).unwrap();
+
+    assert_eq!(new_edges.next(), dag.find_edge(root, a));
+    assert_eq!(new_edges.next(), dag.find_edge(root, b));
+    assert_eq!(new_edges.next(), dag.find_edge(root, c));
+}
+
+#[test]
+fn add_edges_err() {
+    let mut dag = StableDag::<Weight, u32, u32>::new();
+    let root = dag.add_node(Weight);
+    let a = dag.add_node(Weight);
+    let b = dag.add_node(Weight);
+    let c = dag.add_node(Weight);
+
+    let add_edges_result = dag.add_edges(
+        once((root, a, 0))
+            .chain(once((root, b, 1)))
+            .chain(once((root, c, 2)))
+            .chain(once((c, root, 3))),
+    );
+
+    match add_edges_result {
+        Err(WouldCycle(returned_weights)) => assert_eq!(returned_weights, vec![3, 2, 1, 0]),
+        Ok(_) => panic!("Should have been an error"),
+    }
+}
+
+#[test]
+fn add_edges_more() {
+    let mut dag = StableDag::<Weight, u32, u32>::new();
+    let root = dag.add_node(Weight);
+    let a = dag.add_node(Weight);
+    let b = dag.add_node(Weight);
+    let c = dag.add_node(Weight);
+
+    assert!(dag.add_edge(root, a, 0).is_ok());
+    assert!(dag.add_edge(root, b, 0).is_ok());
+    assert!(dag.add_edge(root, c, 0).is_ok());
+    assert!(dag.add_edge(c, root, 0).is_err());
+}
+
+#[test]
+fn add_edges_more2() {
+    let max_node = 10;
+    let edges = &[
+        (1, 4),
+        (3, 4),
+        (2, 5),
+        (3, 5),
+        (2, 8),
+        (1, 9),
+        (1, 8),
+        (1, 3),
+        (2, 7),
+        (1, 7),
+        (0, 6),
+        (1, 2),
+        (0, 7),
+        (1, 6),
+        (2, 4),
+        (0, 1),
+        (0, 9),
+        (2, 9),
+        (2, 6),
+        (0, 4),
+        (2, 3),
+        (0, 2),
+        (0, 3),
+        (0, 5),
+        (0, 8),
+        (1, 5),
+    ];
+    let mut dag = StableDag::<Weight, u32, u32>::with_capacity(max_node, edges.len());
+    for _ in 0..max_node {
+        dag.add_node(Weight);
+    }
+    for &(a, b) in edges {
+        assert!(
+            dag.add_edge(NodeIndex::new(a), NodeIndex::new(b), 0)
+                .is_ok()
+        );
+    }
+}

--- a/tests/iterators_stable.rs
+++ b/tests/iterators_stable.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "stable_dag")]
 extern crate daggy;
 
 use daggy::stabledag::{StableDag, Walker};

--- a/tests/iterators_stable.rs
+++ b/tests/iterators_stable.rs
@@ -1,0 +1,87 @@
+extern crate daggy;
+
+use daggy::stabledag::{StableDag, Walker};
+
+struct Weight;
+
+#[test]
+fn children() {
+    let mut dag = StableDag::<Weight, Weight, u32>::new();
+    let parent = dag.add_node(Weight);
+    let (_, a) = dag.add_child(parent, Weight, Weight);
+    let (_, b) = dag.add_child(parent, Weight, Weight);
+    let (_, c) = dag.add_child(parent, Weight, Weight);
+
+    {
+        let mut children = dag.children(parent).iter(&dag).map(|(_, n)| n);
+        assert_eq!(Some(c), children.next());
+        assert_eq!(Some(b), children.next());
+        assert_eq!(Some(a), children.next());
+        assert_eq!(None, children.next());
+    }
+
+    let (d, _) = dag.add_child(b, Weight, Weight);
+    let (e, _) = dag.add_child(b, Weight, Weight);
+    let (f, _) = dag.add_child(b, Weight, Weight);
+    {
+        let mut children = dag.children(b).iter(&dag).map(|(e, _)| e);
+        assert_eq!(Some(f), children.next());
+        assert_eq!(Some(e), children.next());
+        assert_eq!(Some(d), children.next());
+        assert_eq!(None, children.next());
+    }
+}
+
+#[test]
+fn parents() {
+    let mut dag = StableDag::<Weight, Weight, u32>::new();
+    let child = dag.add_node(Weight);
+    let (a_e, a_n) = dag.add_parent(child, Weight, Weight);
+    let (b_e, b_n) = dag.add_parent(child, Weight, Weight);
+    let (c_e, c_n) = dag.add_parent(child, Weight, Weight);
+    let (d_e, d_n) = dag.add_parent(child, Weight, Weight);
+
+    {
+        let mut parents = dag.parents(child).iter(&dag);
+        assert_eq!(Some((d_e, d_n)), parents.next());
+        assert_eq!(Some((c_e, c_n)), parents.next());
+        assert_eq!(Some((b_e, b_n)), parents.next());
+        assert_eq!(Some((a_e, a_n)), parents.next());
+        assert_eq!(None, parents.next());
+    }
+}
+
+#[test]
+fn weights() {
+    let mut dag = StableDag::<&str, i32, u32>::new();
+    let parent = dag.add_node("0");
+    dag.add_child(parent, 1, "1");
+    dag.add_child(parent, 2, "2");
+    dag.add_child(parent, 3, "3");
+
+    {
+        let mut children = dag.children(parent)
+            .iter(&dag)
+            .map(|(e, n)| (&dag[e], &dag[n]));
+        assert_eq!(Some((&3, &"3")), children.next());
+        assert_eq!(Some((&2, &"2")), children.next());
+        assert_eq!(Some((&1, &"1")), children.next());
+        assert_eq!(None, children.next());
+    }
+
+    {
+        let mut child_edges = dag.children(parent).iter(&dag).map(|(e, _)| &dag[e]);
+        assert_eq!(Some(&3), child_edges.next());
+        assert_eq!(Some(&2), child_edges.next());
+        assert_eq!(Some(&1), child_edges.next());
+        assert_eq!(None, child_edges.next());
+    }
+
+    {
+        let mut child_nodes = dag.children(parent).iter(&dag).map(|(_, n)| &dag[n]);
+        assert_eq!(Some(&"3"), child_nodes.next());
+        assert_eq!(Some(&"2"), child_nodes.next());
+        assert_eq!(Some(&"1"), child_nodes.next());
+        assert_eq!(None, child_nodes.next());
+    }
+}

--- a/tests/stable_indices.rs
+++ b/tests/stable_indices.rs
@@ -1,7 +1,7 @@
+#![cfg(feature = "stable_dag")]
 extern crate daggy;
 
 use daggy::stabledag::StableDag;
-
 
 #[test]
 pub fn remove_nodes() {
@@ -12,15 +12,12 @@ pub fn remove_nodes() {
     let c = dag.add_node(3);
 
     dag.remove_node(b);
-
-
+    
     assert_eq!(Some(&0), dag.node_weight(root));
     assert_eq!(Some(&1), dag.node_weight(a));
     assert_eq!(None, dag.node_weight(b));
     assert_eq!(Some(&3), dag.node_weight(c));
-
 }
-
 
 #[test]
 fn remove_edges() {

--- a/tests/stable_indices.rs
+++ b/tests/stable_indices.rs
@@ -1,0 +1,42 @@
+extern crate daggy;
+
+use daggy::stabledag::StableDag;
+
+
+#[test]
+pub fn remove_nodes() {
+    let mut dag = StableDag::<u32, u32, u32>::new();
+    let root = dag.add_node(0);
+    let a = dag.add_node(1);
+    let b = dag.add_node(2);
+    let c = dag.add_node(3);
+
+    dag.remove_node(b);
+
+
+    assert_eq!(Some(&0), dag.node_weight(root));
+    assert_eq!(Some(&1), dag.node_weight(a));
+    assert_eq!(None, dag.node_weight(b));
+    assert_eq!(Some(&3), dag.node_weight(c));
+
+}
+
+
+#[test]
+fn remove_edges() {
+    let mut dag = StableDag::<u32, u32, u32>::new();
+    let root = dag.add_node(0);
+    let a = dag.add_node(1);
+    let b = dag.add_node(2);
+    let c = dag.add_node(3);
+
+    let e_a = dag.add_edge(root, a, 0).unwrap();
+    let e_b = dag.add_edge(root, b, 1).unwrap();
+    let e_c = dag.add_edge(root, c, 2).unwrap();
+
+    dag.remove_edge(e_b);
+
+    assert_eq!(Some(&0), dag.edge_weight(e_a));
+    assert_eq!(None, dag.edge_weight(e_b));
+    assert_eq!(Some(&2), dag.edge_weight(e_c));
+}

--- a/tests/walkers_stable.rs
+++ b/tests/walkers_stable.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "stable_dag")]
 extern crate daggy;
 
 use daggy::stabledag::{StableDag, Walker};

--- a/tests/walkers_stable.rs
+++ b/tests/walkers_stable.rs
@@ -1,0 +1,345 @@
+extern crate daggy;
+
+use daggy::stabledag::{StableDag, Walker};
+
+#[derive(Copy, Clone, Debug)]
+struct Weight;
+
+#[test]
+fn children() {
+    let mut dag = StableDag::<Weight, Weight>::new();
+    let parent = dag.add_node(Weight);
+    let (_, a_n) = dag.add_child(parent, Weight, Weight);
+    let (b_e, b_n) = dag.add_child(parent, Weight, Weight);
+    let (c_e, c_n) = dag.add_child(parent, Weight, Weight);
+
+    let mut child_walker = dag.children(parent);
+    assert_eq!(Some((c_e, c_n)), child_walker.walk_next(&dag));
+    assert_eq!(Some(b_e), child_walker.walk_next(&dag).map(|(e, _)| e));
+    assert_eq!(Some(a_n), child_walker.walk_next(&dag).map(|(_, n)| n));
+    assert_eq!(None, child_walker.walk_next(&dag));
+
+    let (d_e, d_n) = dag.add_child(b_n, Weight, Weight);
+    let (e_e, e_n) = dag.add_child(b_n, Weight, Weight);
+    let (f_e, f_n) = dag.add_child(b_n, Weight, Weight);
+
+    child_walker = dag.children(b_n);
+    assert_eq!(Some((f_e, f_n)), child_walker.walk_next(&dag));
+    assert_eq!(Some((e_e, e_n)), child_walker.walk_next(&dag));
+    assert_eq!(Some((d_e, d_n)), child_walker.walk_next(&dag));
+    assert_eq!(None, child_walker.walk_next(&dag));
+}
+
+#[test]
+fn parents() {
+    let mut dag = StableDag::<Weight, Weight>::new();
+    let child = dag.add_node(Weight);
+    let (a_e, a_n) = dag.add_parent(child, Weight, Weight);
+    let (b_e, b_n) = dag.add_parent(child, Weight, Weight);
+    let (c_e, c_n) = dag.add_parent(child, Weight, Weight);
+    let (d_e, d_n) = dag.add_parent(child, Weight, Weight);
+
+    let mut parent_walker = dag.parents(child);
+    assert_eq!(Some((d_e, d_n)), parent_walker.walk_next(&dag));
+    assert_eq!(Some((c_e, c_n)), parent_walker.walk_next(&dag));
+    assert_eq!(Some((b_e, b_n)), parent_walker.walk_next(&dag));
+    assert_eq!(Some((a_e, a_n)), parent_walker.walk_next(&dag));
+    assert_eq!(None, parent_walker.walk_next(&dag));
+}
+
+#[test]
+fn count() {
+    let mut dag = StableDag::<Weight, Weight>::new();
+    let parent = dag.add_node(Weight);
+    dag.add_child(parent, Weight, Weight);
+    dag.add_child(parent, Weight, Weight);
+    dag.add_child(parent, Weight, Weight);
+    assert_eq!(3, dag.children(parent).iter(&dag).count());
+}
+
+#[test]
+fn last() {
+    let mut dag = StableDag::<Weight, Weight>::new();
+    let parent = dag.add_node(Weight);
+    let (last_e, last_n) = dag.add_child(parent, Weight, Weight);
+    dag.add_child(parent, Weight, Weight);
+    dag.add_child(parent, Weight, Weight);
+    assert_eq!(
+        Some((last_e, last_n)),
+        dag.children(parent).iter(&dag).last()
+    );
+}
+
+#[test]
+fn nth() {
+    let mut dag = StableDag::<Weight, Weight>::new();
+    let parent = dag.add_node(Weight);
+    let (e_at_2, n_at_2) = dag.add_child(parent, Weight, Weight);
+    let (_, _) = dag.add_child(parent, Weight, Weight);
+    let (_, _) = dag.add_child(parent, Weight, Weight);
+    assert_eq!(None, dag.children(parent).iter(&dag).nth(3));
+    assert_eq!(
+        Some((e_at_2, n_at_2)),
+        dag.children(parent).iter(&dag).nth(2)
+    );
+}
+
+#[test]
+fn chain() {
+    let mut dag = StableDag::<Weight, Weight>::new();
+    let a = dag.add_node(Weight);
+    let (_, b) = dag.add_child(a, Weight, Weight);
+    let (_, c) = dag.add_child(a, Weight, Weight);
+    let (_, d) = dag.add_child(a, Weight, Weight);
+    let (_, e) = dag.add_child(c, Weight, Weight);
+    let (_, f) = dag.add_child(c, Weight, Weight);
+
+    let mut chain = daggy::walker::Chain::new(dag.children(c), dag.children(a));
+    assert_eq!(Some(f), chain.walk_next(&dag).map(|(_, n)| n));
+    assert_eq!(Some(e), chain.walk_next(&dag).map(|(_, n)| n));
+    assert_eq!(Some(d), chain.walk_next(&dag).map(|(_, n)| n));
+    assert_eq!(Some(c), chain.walk_next(&dag).map(|(_, n)| n));
+    assert_eq!(Some(b), chain.walk_next(&dag).map(|(_, n)| n));
+    assert_eq!(None, chain.walk_next(&dag).map(|(_, n)| n));
+}
+
+#[test]
+fn filter() {
+    let mut dag = StableDag::<i32, ()>::new();
+    let parent = dag.add_node(0);
+    dag.add_child(parent, (), 0);
+    dag.add_child(parent, (), 1);
+    dag.add_child(parent, (), 2);
+    dag.add_child(parent, (), 3);
+    dag.add_child(parent, (), 4);
+    dag.add_child(parent, (), 5);
+
+    let children = dag.children(parent);
+    let mut even_children = daggy::walker::Filter::new(children, |g, &(_, n)| g[n] % 2 == 0);
+    assert_eq!(
+        4,
+        dag[even_children.walk_next(&dag).map(|(_, n)| n).unwrap()]
+    );
+    assert_eq!(
+        2,
+        dag[even_children.walk_next(&dag).map(|(_, n)| n).unwrap()]
+    );
+    assert_eq!(
+        0,
+        dag[even_children.walk_next(&dag).map(|(_, n)| n).unwrap()]
+    );
+    assert!(even_children.walk_next(&dag).is_none());
+}
+
+#[test]
+fn peekable() {
+    let mut dag = StableDag::<Weight, Weight>::new();
+    let parent = dag.add_node(Weight);
+    let (_, a) = dag.add_child(parent, Weight, Weight);
+    let (_, b) = dag.add_child(parent, Weight, Weight);
+    let (_, c) = dag.add_child(parent, Weight, Weight);
+
+    let children = dag.children(parent);
+    let mut children = daggy::walker::Peekable::new(children);
+    assert_eq!(Some(c), children.peek(&dag).map(|&(_, n)| n));
+    assert_eq!(Some(c), children.walk_next(&dag).map(|(_, n)| n));
+    assert_eq!(Some(b), children.walk_next(&dag).map(|(_, n)| n));
+    assert_eq!(Some(a), children.peek(&dag).map(|&(_, n)| n));
+    assert_eq!(Some(a), children.peek(&dag).map(|&(_, n)| n));
+    assert_eq!(Some(a), children.walk_next(&dag).map(|(_, n)| n));
+    assert!(children.peek(&dag).is_none());
+    assert!(children.walk_next(&dag).is_none());
+}
+
+#[test]
+fn skip_while() {
+    let mut dag = StableDag::<i32, ()>::new();
+    let parent = dag.add_node(0);
+    dag.add_child(parent, (), 0);
+    dag.add_child(parent, (), 1);
+    dag.add_child(parent, (), 2);
+    dag.add_child(parent, (), 3);
+    dag.add_child(parent, (), 4);
+    dag.add_child(parent, (), 5);
+
+    let children = dag.children(parent);
+    let mut children_under_3 = daggy::walker::SkipWhile::new(children, |g, &(_, n)| g[n] >= 3);
+    assert_eq!(
+        2,
+        dag[children_under_3.walk_next(&dag).map(|(_, n)| n).unwrap()]
+    );
+    assert_eq!(
+        1,
+        dag[children_under_3.walk_next(&dag).map(|(_, n)| n).unwrap()]
+    );
+    assert_eq!(
+        0,
+        dag[children_under_3.walk_next(&dag).map(|(_, n)| n).unwrap()]
+    );
+    assert!(children_under_3.walk_next(&dag).is_none());
+}
+
+#[test]
+fn take_while() {
+    let mut dag = StableDag::<i32, ()>::new();
+    let parent = dag.add_node(0);
+    dag.add_child(parent, (), 0);
+    dag.add_child(parent, (), 1);
+    dag.add_child(parent, (), 2);
+    dag.add_child(parent, (), 3);
+    dag.add_child(parent, (), 4);
+    dag.add_child(parent, (), 5);
+
+    let children = dag.children(parent);
+    let mut children_over_2 = daggy::walker::TakeWhile::new(children, |g, &(_, n)| g[n] > 2);
+    assert_eq!(
+        5,
+        dag[children_over_2.walk_next(&dag).map(|(_, n)| n).unwrap()]
+    );
+    assert_eq!(
+        4,
+        dag[children_over_2.walk_next(&dag).map(|(_, n)| n).unwrap()]
+    );
+    assert_eq!(
+        3,
+        dag[children_over_2.walk_next(&dag).map(|(_, n)| n).unwrap()]
+    );
+    assert!(children_over_2.walk_next(&dag).is_none());
+}
+
+#[test]
+fn skip() {
+    let mut dag = StableDag::<i32, ()>::new();
+    let parent = dag.add_node(0);
+    dag.add_child(parent, (), 0);
+    dag.add_child(parent, (), 1);
+    dag.add_child(parent, (), 2);
+    dag.add_child(parent, (), 3);
+    dag.add_child(parent, (), 4);
+    dag.add_child(parent, (), 5);
+
+    let children = dag.children(parent);
+    let mut children = daggy::walker::Skip::new(children, 3);
+    assert_eq!(2, dag[children.walk_next(&dag).map(|(_, n)| n).unwrap()]);
+    assert_eq!(1, dag[children.walk_next(&dag).map(|(_, n)| n).unwrap()]);
+    assert_eq!(0, dag[children.walk_next(&dag).map(|(_, n)| n).unwrap()]);
+    assert!(children.walk_next(&dag).is_none());
+}
+
+#[test]
+fn take() {
+    let mut dag = StableDag::<i32, ()>::new();
+    let parent = dag.add_node(0);
+    dag.add_child(parent, (), 0);
+    dag.add_child(parent, (), 1);
+    dag.add_child(parent, (), 2);
+    dag.add_child(parent, (), 3);
+    dag.add_child(parent, (), 4);
+    dag.add_child(parent, (), 5);
+
+    let children = dag.children(parent);
+    let mut children = daggy::walker::Take::new(children, 3);
+    assert_eq!(5, dag[children.walk_next(&dag).map(|(_, n)| n).unwrap()]);
+    assert_eq!(4, dag[children.walk_next(&dag).map(|(_, n)| n).unwrap()]);
+    assert_eq!(3, dag[children.walk_next(&dag).map(|(_, n)| n).unwrap()]);
+    assert!(children.walk_next(&dag).is_none());
+}
+
+#[test]
+fn all() {
+    let mut dag = StableDag::<i32, ()>::new();
+    let parent = dag.add_node(0);
+    dag.add_child(parent, (), 0);
+    dag.add_child(parent, (), 2);
+    dag.add_child(parent, (), 4);
+
+    let mut children = dag.children(parent);
+    assert!(children.iter(&dag).all(|(_, n)| dag[n] % 2 == 0));
+
+    dag.add_child(parent, (), 7);
+    children = dag.children(parent);
+    assert!(!children.iter(&dag).all(|(_, n)| dag[n] % 2 == 0));
+}
+
+#[test]
+fn any() {
+    let mut dag = StableDag::<i32, ()>::new();
+    let parent = dag.add_node(0);
+    dag.add_child(parent, (), 1);
+    dag.add_child(parent, (), 3);
+    dag.add_child(parent, (), 5);
+
+    assert!(!dag.children(parent)
+        .iter(&dag)
+        .any(|(_, n)| dag[n] % 2 == 0));
+
+    dag.add_child(parent, (), 6);
+
+    assert!(
+        dag.children(parent)
+            .iter(&dag)
+            .any(|(_, n)| dag[n] % 2 == 0)
+    );
+}
+
+#[test]
+fn find() {
+    let mut dag = StableDag::<i32, ()>::new();
+    let parent = dag.add_node(0);
+    dag.add_child(parent, (), 1);
+    dag.add_child(parent, (), 3);
+    dag.add_child(parent, (), 5);
+
+    assert_eq!(
+        None,
+        dag.children(parent)
+            .iter(&dag)
+            .find(|&(_, n)| dag[n] % 2 == 0)
+    );
+
+    let (e, n) = dag.add_child(parent, (), 4);
+
+    assert_eq!(
+        Some((e, n)),
+        dag.children(parent)
+            .iter(&dag)
+            .find(|&(_, n)| dag[n] % 2 == 0)
+    );
+}
+
+#[test]
+fn fold() {
+    let mut dag = StableDag::<i32, i32>::new();
+    let parent = dag.add_node(0);
+    dag.add_child(parent, 1, 1);
+    dag.add_child(parent, 2, 2);
+    dag.add_child(parent, 3, 3);
+
+    assert_eq!(
+        12,
+        dag.children(parent)
+            .iter(&dag)
+            .fold(0, |acc, (e, n)| acc + dag[e] + dag[n])
+    );
+}
+
+#[test]
+fn recursive_walk() {
+    let mut dag = StableDag::<i32, i32>::new();
+    let grand_parent = dag.add_node(0);
+    let (_, parent) = dag.add_child(grand_parent, 0, 0);
+    let (_, child) = dag.add_child(parent, 0, 0);
+
+    let mut parent_recursion = dag.recursive_walk(child, |g, n| {
+        g.parents(n).iter(g).find(|&(e, n)| g[e] == 0 && g[n] == 0)
+    });
+    assert_eq!(
+        Some(parent),
+        parent_recursion.walk_next(&dag).map(|(_, n)| n)
+    );
+    assert_eq!(
+        Some(grand_parent),
+        parent_recursion.walk_next(&dag).map(|(_, n)| n)
+    );
+    assert_eq!(None, parent_recursion.walk_next(&dag));
+}


### PR DESCRIPTION
This is an early implementation of a StableDag.The code is almost copied from the Dag structure, but using StableGraph instead of Graph.  As indicated in the original commit, there are 4 methods that are not implemented because StableGraph does not provide the necessary functions:

    raw_nodes() -> Because StableGraph lacks raw_nodes().
    node_weights_mut() -> Because StableGraph lacks node_weights_mut().
    raw_edges() -> Because StableGraph lacks raw_edges().
    edge_weights_mut() -> Because StableGraph lacks edge_weights_mut().

I included the same set of tests for StableDag that is used in the Dag structure in the files
tests/add_edges_stable.rs
tests/iterators_stable.rs
tests/walkers_stable.rs

I also included the tests in tests/stable_indices to test that node/edge indices do not change when we remove an edge/node.

I am pretty new to Rust, so it may need some better code / project organization.

