### PR TITLE
Detect an edge from a node to itself.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -641,6 +641,9 @@ fn must_check_for_cycle<N, E, Ix>(dag: &Dag<N, E, Ix>, a: NodeIndex<Ix>, b: Node
 where
     Ix: IndexType,
 {
+    if a == b {
+        return true;
+    }
     dag.parents(a).walk_next(dag).is_some()
         && dag.children(b).walk_next(dag).is_some()
         && dag.find_edge(a, b).is_none()

--- a/src/stable_dag/mod.rs
+++ b/src/stable_dag/mod.rs
@@ -592,6 +592,9 @@ fn must_check_for_cycle<N, E, Ix>(
 where
     Ix: IndexType,
 {
+    if a == b {
+        return true;
+    }
     dag.parents(a).walk_next(dag).is_some()
         && dag.children(b).walk_next(dag).is_some()
         && dag.find_edge(a, b).is_none()

--- a/tests/add_edges.rs
+++ b/tests/add_edges.rs
@@ -46,6 +46,27 @@ fn add_edges_err() {
 }
 
 #[test]
+fn add_edges_err_loop() {
+    let mut dag = Dag::<Weight, u32, u32>::new();
+    let root = dag.add_node(Weight);
+    let a = dag.add_node(Weight);
+    let b = dag.add_node(Weight);
+    let c = dag.add_node(Weight);
+
+    let add_edges_result = dag.add_edges(
+        once((root, a, 0))
+            .chain(once((root, b, 1)))
+            .chain(once((root, c, 2)))
+            .chain(once((c, c, 3))),
+    );
+
+    match add_edges_result {
+        Err(WouldCycle(returned_weights)) => assert_eq!(returned_weights, vec![3, 2, 1, 0]),
+        Ok(_) => panic!("Should detect cycle with self"),
+    }
+}
+
+#[test]
 fn add_edges_more() {
     let mut dag = Dag::<Weight, u32, u32>::new();
     let root = dag.add_node(Weight);

--- a/tests/add_edges_stable.rs
+++ b/tests/add_edges_stable.rs
@@ -47,6 +47,27 @@ fn add_edges_err() {
 }
 
 #[test]
+fn add_edges_err_loop() {
+    let mut dag = StableDag::<Weight, u32, u32>::new();
+    let root = dag.add_node(Weight);
+    let a = dag.add_node(Weight);
+    let b = dag.add_node(Weight);
+    let c = dag.add_node(Weight);
+
+    let add_edges_result = dag.add_edges(
+        once((root, a, 0))
+            .chain(once((root, b, 1)))
+            .chain(once((root, c, 2)))
+            .chain(once((c, c, 3))),
+    );
+
+    match add_edges_result {
+        Err(WouldCycle(returned_weights)) => assert_eq!(returned_weights, vec![3, 2, 1, 0]),
+        Ok(_) => panic!("Should detect cycle with self"),
+    }
+}
+
+#[test]
 fn add_edges_more() {
     let mut dag = StableDag::<Weight, u32, u32>::new();
     let root = dag.add_node(Weight);


### PR DESCRIPTION
Fixes #28.

Heya, I just added the code suggested by @jdeschenes for both `Dag` and `StableDag`.