### PR TITLE
Add reserve_ and shrink_ functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## unreleased
 
-* Add `Dag::transitive_reduce` ([#36][#36]).
+* Add `Dag::transitive_reduce` ([#36][#36], [#41][#41]).
+* Add `Dag::{reserve_*, shrink_*}` functions ([#38][#38]).
+    - `reserve_nodes`
+    - `reserve_exact_nodes`
+    - `reserve_edges`
+    - `reserve_exact_edges`
+    - `shrink_to_fit`
+    - `shrink_to_fit_nodes`
+    - `shrink_to_fit_edges`
 
 [#36]: https://github.com/mitchmindtree/daggy/pull/36
+[#38]: https://github.com/mitchmindtree/daggy/pull/38
+[#41]: https://github.com/mitchmindtree/daggy/pull/41

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,6 +258,59 @@ where
         self.graph.edge_count()
     }
 
+    /// Reserves capacity for at least `additional` more nodes to be inserted in
+    /// the graph. Graph may reserve more space to avoid frequent reallocations.
+    ///
+    /// **Panics** if the new capacity overflows `usize`.
+    pub fn reserve_nodes(&mut self, additional: usize) {
+        self.graph.reserve_nodes(additional)
+    }
+
+    /// Reserves the minimum capacity for exactly `additional` more nodes to be
+    /// inserted in the graph. Does nothing if the capacity is already
+    /// sufficient.
+    ///
+    /// Prefer `reserve_nodes` if future insertions are expected.
+    ///
+    /// **Panics** if the new capacity overflows `usize`.
+    pub fn reserve_exact_nodes(&mut self, additional: usize) {
+        self.graph.reserve_exact_nodes(additional)
+    }
+
+    /// Reserves capacity for at least `additional` more edges to be inserted in
+    /// the graph. Graph may reserve more space to avoid frequent reallocations.
+    ///
+    /// **Panics** if the new capacity overflows `usize`.
+    pub fn reserve_edges(&mut self, additional: usize) {
+        self.graph.reserve_edges(additional)
+    }
+
+    /// Reserves the minimum capacity for exactly `additional` more edges to be
+    /// inserted in the graph.
+    /// Does nothing if the capacity is already sufficient.
+    ///
+    /// Prefer `reserve_edges` if future insertions are expected.
+    ///
+    /// **Panics** if the new capacity overflows `usize`.
+    pub fn reserve_exact_edges(&mut self, additional: usize) {
+        self.graph.reserve_exact_edges(additional)
+    }
+
+    /// Shrinks the capacity of the graph as much as possible.
+    pub fn shrink_to_fit(&mut self) {
+        self.graph.shrink_to_fit();
+    }
+
+    /// Shrinks the capacity of the underlying nodes collection as much as possible.
+    pub fn shrink_to_fit_nodes(&mut self) {
+        self.graph.shrink_to_fit_nodes();
+    }
+
+    /// Shrinks the capacity of the underlying edges collection as much as possible.
+    pub fn shrink_to_fit_edges(&mut self) {
+        self.graph.shrink_to_fit_edges();
+    }
+
     /// Borrow the `Dag`'s underlying `DiGraph<N, Ix>`.
     ///
     /// All existing indices may be used to index into this `DiGraph` the same way they may be


### PR DESCRIPTION
This simply exposes the capacity-related functions from the petgraph Graph.