### PR TITLE
allow iter to transitive_reduce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.0 (2025-07-28)
+
+* Backwards compatible edit to transitive_reduce (allow iter arg)
+
 ## 0.9.0 (2025-04-18)
 
 * Update `petgraph` to `0.8` ([#43][#43]).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "daggy"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "A directed acyclic graph data structure library. It is Implemented on top of petgraph's Graph data structure and attempts to follow similar conventions where suitable."
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Use daggy in your project by adding it to your `Cargo.toml` dependencies:
 
 ```toml
 [dependencies]
-daggy = "0.9.0"
+daggy = "0.10.0"
 
 # Enables the `StableDag` type.
-daggy = { version = "0.9.0", features = ["stable_dag"] }
+daggy = { version = "0.10.0", features = ["stable_dag"] }
 
 # Allows the `Dag` to be serialized and deserialized.
-daggy = { version = "0.9.0", features = ["serde-1"] }
+daggy = { version = "0.10.0", features = ["serde-1"] }
 ```
 
 ## Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,13 +19,13 @@
 //!
 //! ```toml
 //! [dependencies]
-//! daggy = "0.9.0"
+//! daggy = "0.10.0"
 //!
 //! # Enables the `StableDag` type.
-//! daggy = { version = "0.9.0", features = ["stable_dag"] }
+//! daggy = { version = "0.10.0", features = ["stable_dag"] }
 //!
 //! # Allows the `Dag` to be serialized and deserialized.
-//! daggy = { version = "0.9.0", features = ["serde-1"] }
+//! daggy = { version = "0.10.0", features = ["serde-1"] }
 //! ```
 //!
 //! # Examples
@@ -783,7 +783,10 @@ where
     }
 
     /// Mutates the DAG into its [transitive reduction](https://en.wikipedia.org/wiki/Directed_acyclic_graph#Transitive_closure_and_transitive_reduction)
-    pub fn transitive_reduce(&mut self, roots: Vec<NodeIndex<Ix>>) {
+    pub fn transitive_reduce<I>(&mut self, roots: I)
+    where
+        I: IntoIterator<Item = NodeIndex<Ix>>,
+    {
         for root in roots {
             self.transitive_reduce_iter(root, &mut Vec::new())
         }


### PR DESCRIPTION
```rust
// new (now allowed)
let mut my_nodes = HashSet::<NodeIndex<DefaultIx>>::default();
my_nodes.insert(a);
dag.transitive_reduce(my_nodes.iter().map(|e| *e));

// old (still works)
// dag.transitive_reduce(vec![a]);
```